### PR TITLE
Add DBAL 4 compatibility and effective PostgreSQL RLS coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-RC3] - 2026-04-05
+
+### Fixed
+- Replaced the false-positive RLS target with six effective PostgreSQL 16 tests using a non-superuser application role and raw DBAL queries.
+- Persisted the PostgreSQL tenant setting for the database session and clear stale tenant state when no context is active.
+
+### Added
+- **Symfony 8.0 & 7.4 Compatibility**
+  - Updated `composer.json` to support Symfony `^7.4` and `^8.0` components
+  - Updated `symfony/contracts` to support `^3.4` and `^4.0`
+  - Ensured compatibility with PHP 8.3+ (as required by Symfony 8)
+- **Doctrine DBAL 4 Support**
+  - Refactored database platform detection to use `instanceof PostgreSQLPlatform` instead of deprecated `getName()`
+  - Updated `DriverManager::getConnection()` calls to handle stricter type-hinting in DBAL 4
+  - Updated `executeStatement()` return type handling in tests (now returns `int|string`)
+  - Updated `Doctrine\DBAL\Exception` handling for interface-based exceptions in DBAL 4
+- **Test Suite Updates**
+  - Updated `SubdomainTenantResolver` tests for correct constructor arguments
+  - Fixed various unit tests to support DBAL 4 changes and stricter typing
+  - Updated `Makefile` to use `docker compose` (v2) instead of legacy `docker-compose`
+- **Documentation Updates**
+  - Updated `README.md` and documentation files to reflect Symfony 8 support
+
 ## [1.0.0-RC2]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 PHP_IMAGE := php:8.3-cli
 DOCKER_VOLUME := -v "$(PWD)":/app -w /app
-DOCKER_RUN := docker run --rm -it $(DOCKER_VOLUME) $(PHP_IMAGE)
+DOCKER_RUN := docker run --rm $(DOCKER_VOLUME) $(PHP_IMAGE)
 
 ## —— 🎵 🐳 Zhortein's Multi-Tenant Bundle Makefile 🐳 🎵 ——————————————————————————————————
 help: ## 📖 Show available commands
@@ -22,7 +22,8 @@ installdeps: ## Install Composer deps in container
 		php composer.phar install"
 
 updatedeps: ## Update Composer deps in container
-	$(DOCKER_RUN) bash -c "php composer.phar update"
+	$(DOCKER_RUN) bash -c "apt update && apt install -y unzip git zip curl > /dev/null && \
+		php composer.phar update"
 
 composer: ## Run composer in container (usage: make composer ARGS="require symfony/yaml")
 	@$(DOCKER_RUN) php composer.phar $(ARGS)
@@ -50,7 +51,7 @@ test-kit: ## Run Test Kit integration tests
 	$(DOCKER_RUN) vendor/bin/phpunit tests/Integration --no-coverage
 
 test-rls: ## Run RLS isolation tests (requires PostgreSQL)
-	$(DOCKER_RUN) vendor/bin/phpunit tests/Integration/RlsIsolationTest.php --no-coverage
+	docker compose -f tests/docker-compose.yml run --rm php-rls vendor/bin/phpunit tests/Integration/RlsIsolationTest.php --no-coverage
 
 test-resolvers: ## Run resolver chain tests
 	$(DOCKER_RUN) vendor/bin/phpunit tests/Integration/ResolverChainHttpTest.php tests/Integration/ResolverChainTest.php --no-coverage
@@ -82,25 +83,29 @@ phpstan-baseline: ## Generate PHPStan baseline
 ## —— 🐘 PostgreSQL Test Environment ——————————————————————————————————————————————————————
 postgres-start: ## Start PostgreSQL test container
 	@echo "🐘 Starting PostgreSQL test container..."
-	cd tests && docker-compose up -d postgres
+	cd tests && docker compose up -d postgres
 	@echo "⏳ Waiting for PostgreSQL to be ready..."
-	cd tests && docker-compose exec postgres pg_isready -U test_user -d multi_tenant_test || sleep 5
+	cd tests && docker compose exec postgres pg_isready -U test_user -d multi_tenant_test || sleep 5
 	@echo "✅ PostgreSQL is ready!"
 
 postgres-stop: ## Stop PostgreSQL test container
 	@echo "🛑 Stopping PostgreSQL test container..."
-	cd tests && docker-compose down
+	cd tests && docker compose down
 
 postgres-logs: ## Show PostgreSQL logs
-	cd tests && docker-compose logs postgres
+	cd tests && docker compose logs postgres
 
 postgres-shell: ## Connect to PostgreSQL shell
-	cd tests && docker-compose exec postgres psql -U test_user -d multi_tenant_test
+	cd tests && docker compose exec postgres psql -U test_user -d multi_tenant_test
 
-test-with-postgres: postgres-start test-rls postgres-stop ## Run RLS tests with PostgreSQL
+test-with-postgres: ## Run RLS tests with PostgreSQL
+	@set -e; \
+	trap 'docker compose -f tests/docker-compose.yml down' EXIT; \
+	docker compose -f tests/docker-compose.yml up -d --wait postgres; \
+	docker compose -f tests/docker-compose.yml run --rm php-rls vendor/bin/phpunit tests/Integration/RlsIsolationTest.php --no-coverage
 
 validate-testkit: ## Validate Test Kit setup and configuration
-	$(DOCKER_RUN) php tests/validate-testkit.php
+	docker compose -f tests/docker-compose.yml run --rm --no-deps php-rls php tests/validate-testkit.php
 
 ## —— 🔧 Bundle-specific ———————————————————————————————————————————————————————————————————
 bundle-validate: ## Validate bundle structure

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Zhortein Multi-Tenant Bundle
 
-A comprehensive Symfony 7+ bundle for building multi-tenant applications with PostgreSQL 16 support.
+A comprehensive Symfony 7.4+ and 8.0+ bundle for building multi-tenant applications with PostgreSQL 16 support.
 
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D8.3-blue.svg)](https://php.net/)
-[![Symfony Version](https://img.shields.io/badge/symfony-%3E%3D7.0-green.svg)](https://symfony.com/)
+[![Symfony Version](https://img.shields.io/badge/symfony-%3E%3D7.4%20%7C%208.0-green.svg)](https://symfony.com/)
 [![PostgreSQL Version](https://img.shields.io/badge/postgresql-16-blue.svg)](https://www.postgresql.org/)
 
 ## Features

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "zhortein/multi-tenant-bundle",
   "type": "symfony-bundle",
-  "description": "A comprehensive Symfony 7+ bundle for building multi-tenant applications with PostgreSQL 16 support, featuring multiple resolution strategies, tenant-aware services, and automatic database filtering.",
+  "description": "A comprehensive Symfony 7.4+ and 8.0+ bundle for building multi-tenant applications with PostgreSQL 16 support, featuring multiple resolution strategies, tenant-aware services, and automatic database filtering.",
   "keywords": ["symfony", "symfony-bundle", "multi-tenant", "multitenant", "tenant", "multi-tenancy", "subdomain", "domain", "dns", "postgresql", "doctrine", "orm", "mailer", "messenger", "storage", "saas", "hosting"],
   "homepage": "https://github.com/zhortein/multi-tenant-bundle",
   "license": "MIT",
@@ -20,16 +20,15 @@
   ],
   "require": {
     "php": ">=8.3",
-    "doctrine/annotations": "^2.0",
     "doctrine/doctrine-bundle": "^2.7",
     "doctrine/doctrine-migrations-bundle": "^3.0",
     "monolog/monolog": "^3",
-    "symfony/cache": "^7.0",
-    "symfony/config": " ^7.0",
-    "symfony/contracts": " ^3.0",
-    "symfony/dependency-injection": "^7.0",
-    "symfony/filesystem": "^7.0",
-    "symfony/http-kernel": " ^7.0",
+    "symfony/cache": "^7.4 || ^8.0",
+    "symfony/config": "^7.4 || ^8.0",
+    "symfony/contracts": "^3.4 || ^4.0",
+    "symfony/dependency-injection": "^7.4 || ^8.0",
+    "symfony/filesystem": "^7.4 || ^8.0",
+    "symfony/http-kernel": "^7.4 || ^8.0",
     "symfony/orm-pack": "^2.0"
   },
   "require-dev": {
@@ -41,11 +40,11 @@
     "phpunit/phpunit": "^12.2.5",
     "psr/simple-cache": "*",
     "roave/security-advisories": "dev-latest",
-    "symfony/mailer": "^7.0",
-    "symfony/messenger": "^7.0",
-    "symfony/phpunit-bridge": "^7.3",
-    "symfony/test-pack": "^1.0",
-    "symfony/twig-bundle": "^7.0"
+    "symfony/mailer": "^7.4 || ^8.0",
+    "symfony/messenger": "^7.4 || ^8.0",
+    "symfony/phpunit-bridge": "^7.4 || ^8.0",
+    "symfony/test-pack": "^1.1",
+    "symfony/twig-bundle": "^7.4 || ^8.0"
   },
   "config": {
     "sort-packages": true

--- a/docs/audit-2026-07.md
+++ b/docs/audit-2026-07.md
@@ -1,0 +1,110 @@
+# Technical Audit — July 2026
+
+## Executive summary
+
+The repository provides a broad and promising foundation, but the published state should not yet be described as production-ready. Tenant context, resolvers, Doctrine filtering, commands, Messenger, Mailer, storage, cache, observability, and PostgreSQL RLS are implemented, and 410 tests are discovered. However, public documentation diverges from the actual configuration, compatibility claims are not exercised as a matrix, many tests are skipped, and isolation guarantees outside the ORM remain insufficiently demonstrated.
+
+Health status: **amber**. The project requires substantial stabilization and verification before a stable 1.0 release.
+
+## Git state and local changes
+
+### Published GitHub state
+
+- Public repository with `main` as its default branch; last code push was August 29, 2025.
+- `main` points to `0dcd67b`; no tags or releases exist.
+- Four pull requests from `develop` to `main` have been merged.
+- Issue #5, concerning maintenance intentions, was the only open issue before this audit and was not modified.
+- No milestones existed before this audit.
+
+### Local branch
+
+- Local `develop` points to `e6d3925` and matches `origin/develop`.
+- `develop` contains commits newer than the last merge into `main`.
+- No files were staged and no untracked files existed at initial inspection.
+
+### Preserved uncommitted changes
+
+Nineteen tracked files were already modified: 74 insertions and 55 deletions across `.phpunit.cache/test-results`, `CHANGELOG.md`, `Makefile`, `README.md`, `composer.json`, two documentation files, four DBAL/RLS/cache/DI classes, and eight tests.
+
+Those changes already remove `doctrine/annotations`, correct suspicious Composer whitespace, propose Symfony 7.4/8.0 and DBAL 4 support, replace deprecated PostgreSQL platform detection, and adapt tests to DBAL 4 signatures. These local fixes are not reported as equivalent unresolved defects. None of those existing files was modified by the audit.
+
+## Compatibility and dependencies
+
+| Area | Published `origin/develop` | Uncommitted local state | Evidence |
+|---|---|---|---|
+| PHP | `>=8.3` | unchanged | local tests on PHP 8.3 only |
+| Symfony | components `^7.0` | `^7.4 || ^8.0` | no 7.4/8 matrix |
+| Doctrine DBAL | transitive through ORM pack | DBAL 4 adaptations | no DBAL 3/4 jobs |
+| PHPUnit | `^12.2.5` | unchanged | 12.5.16 run on PHP 8.3 |
+| PHPStan | `^2.1`, maximum level | unchanged | passes locally |
+| PostgreSQL | documentation claims 16 | unchanged | CI uses PostgreSQL 16 only |
+
+PHP 8.4/8.5, Symfony 7.4/8, and supported Doctrine combinations are not confirmed. Production requirements should name the components actually used, while optional integrations should remain optional. The concrete Monolog dependency should also be reviewed in favor of PSR contracts where possible.
+
+The production PSR-4 mapping is coherent. The advertised test kit is under `autoload-dev` and is therefore not normally available to consuming applications.
+
+## Demonstrated functionality
+
+- Tenant context, in-memory/Doctrine registries, and events.
+- Path, subdomain, header, query, domain, DNS TXT, hybrid, and chain resolvers.
+- Doctrine filtering for attributed entities and multiple identifier forms.
+- Messenger stamp/middleware and context restoration in tests.
+- Tenant-aware Mailer, PSR-6/PSR-16 cache decorators, and local storage.
+- Core commands, observability events/subscribers, and a null metrics adapter.
+- Maximum-level PHPStan and Symfony style checks for `src/` and `tests/`.
+
+## Implemented but insufficiently tested
+
+- RLS requires a real PostgreSQL environment, while 76 tests in the current suite are skipped. `FORCE ROW LEVEL SECURITY`, owner roles, transactions, pooling, and session cleanup need explicit evidence.
+- Multi-database factories and resolvers exist, but tenant connection reuse in workers and long-running processes is not adequately tested.
+- The S3 implementation has no clearly declared backend dependency or backend integration test.
+- Migration and fixture commands lack comprehensive failure and recovery cases.
+- Cache, Mailer, Messenger, and observability lack proof from a real consuming application.
+
+## Documented but not confirmed
+
+- “Production-ready” and “complete data isolation.”
+- PHP 8.4/8.5, Symfony 7.4/8, and DBAL 4 compatibility.
+- Installation through a stable `composer require`; no stable tag exists.
+- Protection of native SQL: Doctrine filters do not apply to DBAL/native SQL.
+- A test kit that consumers can install and use directly.
+- Several S3 and configuration examples.
+
+## Defects and documentation debt
+
+- The quick start documents `resolver.type`, while the configuration tree expects a scalar `resolver`.
+- The README imports `Entity\TenantAwareEntityTrait`, which does not exist; relevant traits are under `Doctrine`.
+- Several guides repeat the obsolete resolver shape or options absent from the configuration tree.
+- `config/services.yaml` contains Doctrine resource paths and a global connection-factory replacement that require validation in a minimal app.
+- Documentation mixes implemented APIs, conceptual examples, and hypothetical APIs without marking their status.
+- The changelog names release candidates for which no tags or releases exist.
+- CI tests only PHP 8.3, uses `actions/cache@v3`, omits style checks, and repeats some suites.
+
+## Security risks
+
+The primary risk is cross-tenant leakage when context is missing, a Doctrine filter is disabled, DBAL/native SQL bypasses ORM filtering, or a multi-database connection/RLS session is reused. Header and query resolvers require explicit trust boundaries. Storage paths must reject traversal and unsafe tenant identifiers. Logs, metrics, caches, messages, and emails must avoid key collisions and unintended identifier exposure.
+
+A documented threat model, adversarial tests, and fail-closed behavior are required before recommending production use.
+
+## Quality checks
+
+- `composer validate --strict` on PHP 8.3: passed.
+- PHPUnit 12.5.16 on PHP 8.3: passed with reservations; 410 tests, 1,035 assertions, 263 notices, and 76 skipped tests.
+- PHPStan 2.x at maximum level across 91 files: passed.
+- PHP-CS-Fixer 3.94.2 with `@Symfony`, separate dry runs for `src` and `tests`: passed.
+- Dedicated PostgreSQL RLS suite: not run separately; database-dependent tests were skipped by the general run.
+- PHP 8.4/8.5, Symfony 7.4/8, DBAL 3/4: not run because no reproducible matrix currently exists.
+
+## Recommendations and effort
+
+First establish reproducible installation and a supported version matrix. Then stabilize canonical configuration with deprecation paths and strengthen isolation evidence before documenting a 1.0 release.
+
+Qualitative effort: **large, approximately 6–10 person-weeks**, with a significant portion devoted to tests and documentation rather than new features.
+
+## Post-audit RLS harness remediation
+
+The initial quality report contained a false positive: `make test-with-postgres` started PostgreSQL but selected `tests/Integration/RlsIsolationTest.php`, whose `TenantWebTestCase` base skipped all six methods because the bundle had no configured test kernel. The command exited successfully with zero assertions. A second hidden problem was that the Compose `POSTGRES_USER` role is a superuser and therefore bypasses PostgreSQL RLS, including forced policies.
+
+The repaired harness now builds a PHP 8.3 test image with `pdo_pgsql`, waits for PostgreSQL 16 health, and makes database availability mandatory. Schema setup uses the administrative role, while all security assertions use a separate non-superuser role. Six tests with 24 assertions verify policy metadata, forced RLS, allowed same-tenant reads and writes, denied cross-tenant reads and writes, tenant switching, raw SQL isolation without the Doctrine filter, and fail-closed behavior when the tenant session is cleared.
+
+The real database tests also exposed an implementation defect: `TenantSessionConfigurator` used transaction-local `set_config(..., true)` outside guaranteed transactions. Tenant state could disappear before protected queries, and a request without a tenant did not clear prior session state. The configurator now uses session-scoped values and explicitly clears the setting when context is absent and after Messenger handling.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Zhortein Multi-Tenant Bundle Documentation
 
-Welcome to the comprehensive documentation for the Zhortein Multi-Tenant Bundle, a powerful Symfony 7+ solution for building multi-tenant applications with PostgreSQL 16 support.
+Welcome to the comprehensive documentation for the Zhortein Multi-Tenant Bundle, a powerful Symfony 7.4+ and 8.0+ solution for building multi-tenant applications with PostgreSQL 16 support.
 
 > 📖 **Quick Start**: New to the bundle? Check out the [main README](../README.md) for installation and quick start guide.
 
@@ -62,7 +62,7 @@ Welcome to the comprehensive documentation for the Zhortein Multi-Tenant Bundle,
 
 ## Overview
 
-The Zhortein Multi-Tenant Bundle provides a comprehensive, production-ready solution for building multi-tenant applications with Symfony 7+. It follows Symfony best practices and includes extensive testing and documentation.
+The Zhortein Multi-Tenant Bundle provides a comprehensive, production-ready solution for building multi-tenant applications with Symfony 7.4+ and 8.0+. It follows Symfony best practices and includes extensive testing and documentation.
 
 ### Key Features
 
@@ -82,7 +82,7 @@ The Zhortein Multi-Tenant Bundle provides a comprehensive, production-ready solu
 ### Technical Requirements
 
 - **PHP**: >= 8.3
-- **Symfony**: >= 7.0
+- **Symfony**: >= 7.4 | 8.0
 - **Database**: PostgreSQL 16 (via Doctrine ORM)
 - **Extensions**: `ext-json`, `ext-pdo`
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,13 +1,13 @@
 # Installation & Setup
 
-This guide walks you through installing and configuring the Zhortein Multi-Tenant Bundle for Symfony 7+ applications.
+This guide walks you through installing and configuring the Zhortein Multi-Tenant Bundle for Symfony 7.4+ and 8.0+ applications.
 
 > 📖 **Navigation**: [← Back to Documentation Index](index.md) | [Configuration →](configuration.md)
 
 ## Requirements
 
 - **PHP**: >= 8.3
-- **Symfony**: >= 7.0
+- **Symfony**: >= 7.4 | 8.0
 - **PostgreSQL**: >= 16 (recommended)
 - **Doctrine ORM**: >= 3.0
 

--- a/docs/rls-security.md
+++ b/docs/rls-security.md
@@ -87,7 +87,7 @@ class Product
 1. The `TenantRequestListener` resolves the tenant from the request
 2. The `TenantSessionConfigurator` sets the PostgreSQL session variable:
    ```sql
-   SELECT set_config('app.tenant_id', '123', true);
+   SELECT set_config('app.tenant_id', '123', false);
    ```
 3. RLS policies automatically filter queries based on this session variable
 

--- a/docs/roadmap-proposal-2026-07.md
+++ b/docs/roadmap-proposal-2026-07.md
@@ -1,0 +1,93 @@
+# Cross-Repository Roadmap Proposal — July 2026
+
+## Principles and recommended sequence
+
+This roadmap follows the joint audit and deduplication of all existing issues, pull requests, releases, and milestones. Bundle issue #5 was the only pre-existing issue; it concerns maintenance intentions and remains open without any comment or modification.
+
+Recommended sequence:
+
+1. Reproducibility and supported version matrix.
+2. Public API, canonical configuration, and dependency boundaries.
+3. Security, isolation, and long-running process behavior.
+4. Demo application as an automated consumer test.
+5. Verified documentation and stable 1.0 release preparation.
+
+Future Services Locaux requirements are treated only as motivating use cases for generic extension points. The bundle must remain public, product-independent, and reusable.
+
+## GitHub milestones
+
+### Bundle
+
+1. **Reproducibility and Supported Baseline**
+2. **Public API and Compatibility**
+3. **Tenant Isolation and Integrations**
+4. **Verified Documentation and 1.0**
+
+### Demo application
+
+1. **Reproducible Integration Baseline**
+2. **Automated Bundle Validation**
+
+## Planned issues
+
+### `Zhortein/multi-tenant-bundle`
+
+- Execute a PHP 8.3–8.5, Symfony 7.4/8, and Doctrine DBAL/ORM CI matrix.
+- Minimize and classify production dependencies for a reusable Symfony bundle.
+- Validate installation in a minimal Symfony application.
+- Stabilize configuration and provide deprecation paths for legacy shapes.
+- Define the shared-database/native SQL/RLS threat model and guarantees.
+- Prove multi-database isolation in long-running processes.
+- Stabilize Mailer, Messenger, cache, storage, and observability contracts.
+- Package the test kit as a consumable API.
+- Align documentation, examples, changelog, tags, and the 1.0 release process.
+
+### `Zhortein/multi-tenant-demo`
+
+- Align PHP, Symfony, Doctrine, and the bundle reference.
+- Make Docker and Composer installation immutable and safe.
+- Enable migrations, schema validation, and PHPUnit in CI.
+- Add authentication, authorization, and deterministic fixtures.
+- Prove end-to-end cross-tenant isolation.
+- Validate Mailer, Messenger, storage, and cache while aligning documentation with implemented journeys.
+
+## Required issue structure
+
+Every created issue includes verified context, current behavior, expected outcome, acceptance criteria, compatibility risks, expected tests, expected documentation, dependencies or blockers, proposed priority, and qualitative estimate.
+
+## Verified GitHub links
+
+### Bundle milestones
+
+- [1. Reproducibility and Supported Baseline](https://github.com/Zhortein/multi-tenant-bundle/milestone/1)
+- [2. Public API and Compatibility](https://github.com/Zhortein/multi-tenant-bundle/milestone/4)
+- [3. Tenant Isolation and Integrations](https://github.com/Zhortein/multi-tenant-bundle/milestone/3)
+- [4. Verified Documentation and 1.0](https://github.com/Zhortein/multi-tenant-bundle/milestone/2)
+
+### Bundle issues
+
+- [#6 — PHP, Symfony, and Doctrine compatibility matrix](https://github.com/Zhortein/multi-tenant-bundle/issues/6)
+- [#7 — Production dependency boundaries](https://github.com/Zhortein/multi-tenant-bundle/issues/7)
+- [#8 — Minimal Symfony application installation](https://github.com/Zhortein/multi-tenant-bundle/issues/8)
+- [#9 — Public configuration and deprecations](https://github.com/Zhortein/multi-tenant-bundle/issues/9)
+- [#10 — Consumable test kit](https://github.com/Zhortein/multi-tenant-bundle/issues/10)
+- [#11 — Multi-database isolation in long-running processes](https://github.com/Zhortein/multi-tenant-bundle/issues/11)
+- [#12 — Tenant-aware integration contracts](https://github.com/Zhortein/multi-tenant-bundle/issues/12)
+- [#13 — Documentation and 1.0 release process](https://github.com/Zhortein/multi-tenant-bundle/issues/13)
+- [#14 — Shared-database and RLS threat model](https://github.com/Zhortein/multi-tenant-bundle/issues/14)
+
+### Demo milestones
+
+- [1. Reproducible Integration Baseline](https://github.com/Zhortein/multi-tenant-demo/milestone/1)
+- [2. Automated Bundle Validation](https://github.com/Zhortein/multi-tenant-demo/milestone/2)
+
+### Demo issues
+
+- [#2 — Mailer, Messenger, storage, and cache validation](https://github.com/Zhortein/multi-tenant-demo/issues/2)
+- [#3 — PHP, Symfony, Doctrine, and bundle alignment](https://github.com/Zhortein/multi-tenant-demo/issues/3)
+- [#4 — Safe Docker and Composer installation](https://github.com/Zhortein/multi-tenant-demo/issues/4)
+- [#5 — CI migrations, schema validation, and PHPUnit](https://github.com/Zhortein/multi-tenant-demo/issues/5)
+- [#6 — End-to-end cross-tenant isolation](https://github.com/Zhortein/multi-tenant-demo/issues/6)
+- [#7 — Authentication, authorization, and fixtures](https://github.com/Zhortein/multi-tenant-demo/issues/7)
+
+All milestone associations were verified after creation. Bundle [issue #5](https://github.com/Zhortein/multi-tenant-bundle/issues/5) remains open without any comment or modification.

--- a/src/Command/CreateTenantCommand.php
+++ b/src/Command/CreateTenantCommand.php
@@ -17,6 +17,9 @@ use Zhortein\MultiTenantBundle\Entity\TenantInterface;
 )]
 final class CreateTenantCommand extends Command
 {
+    /**
+     * @param class-string<TenantInterface> $tenantEntityClass
+     */
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly string $tenantEntityClass,

--- a/src/Command/SyncRlsPoliciesCommand.php
+++ b/src/Command/SyncRlsPoliciesCommand.php
@@ -6,6 +6,7 @@ namespace Zhortein\MultiTenantBundle\Command;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -160,10 +161,6 @@ HELP
         foreach ($allMetadata as $metadata) {
             $reflectionClass = $metadata->getReflectionClass();
 
-            if (!$reflectionClass instanceof \ReflectionClass) {
-                continue;
-            }
-
             $attributes = $reflectionClass->getAttributes(AsTenantAware::class);
 
             if (!empty($attributes)) {
@@ -274,6 +271,6 @@ HELP
      */
     private function isPostgreSQL(): bool
     {
-        return str_contains($this->connection->getDatabasePlatform()->getName(), 'postgresql');
+        return $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform;
     }
 }

--- a/src/Database/TenantSessionConfigurator.php
+++ b/src/Database/TenantSessionConfigurator.php
@@ -6,6 +6,7 @@ namespace Zhortein\MultiTenantBundle\Database;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -116,6 +117,7 @@ final readonly class TenantSessionConfigurator implements MiddlewareInterface
 
         if (null === $tenant) {
             $this->logger?->debug('No tenant context available for RLS configuration');
+            $this->clearTenantSession();
 
             return;
         }
@@ -132,7 +134,7 @@ final readonly class TenantSessionConfigurator implements MiddlewareInterface
 
             // Set the session variable for RLS policies
             $this->connection->executeStatement(
-                'SELECT set_config(?, ?, true)',
+                'SELECT set_config(?, ?, false)',
                 [$this->sessionVariable, $tenantId]
             );
 
@@ -168,8 +170,8 @@ final readonly class TenantSessionConfigurator implements MiddlewareInterface
         try {
             if ($this->isPostgreSQL()) {
                 $this->connection->executeStatement(
-                    'SELECT set_config(?, NULL, true)',
-                    [$this->sessionVariable]
+                    'SELECT set_config(?, ?, false)',
+                    [$this->sessionVariable, '']
                 );
 
                 $this->logger?->debug('Cleared PostgreSQL session variable for RLS', [
@@ -189,6 +191,6 @@ final readonly class TenantSessionConfigurator implements MiddlewareInterface
      */
     private function isPostgreSQL(): bool
     {
-        return str_contains($this->connection->getDatabasePlatform()->getName(), 'postgresql');
+        return $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform;
     }
 }

--- a/src/Decorator/TenantAwareCacheDecorator.php
+++ b/src/Decorator/TenantAwareCacheDecorator.php
@@ -46,11 +46,11 @@ final class TenantAwareCacheDecorator implements CacheItemPoolInterface
         $keyMap = array_combine($prefixedKeys, $keys);
 
         foreach ($items as $prefixedKey => $item) {
-            if (!$item instanceof CacheItemInterface) {
+            if (!$item instanceof CacheItemInterface || !is_string($prefixedKey)) {
                 continue;
             }
             $originalKey = $keyMap[$prefixedKey] ?? $prefixedKey;
-            $result[(string) $originalKey] = new TenantAwareCacheItem($item, (string) $originalKey);
+            $result[$originalKey] = new TenantAwareCacheItem($item, $originalKey);
         }
 
         return $result;

--- a/src/DependencyInjection/Compiler/ConditionalCacheDecoratorsPass.php
+++ b/src/DependencyInjection/Compiler/ConditionalCacheDecoratorsPass.php
@@ -19,8 +19,8 @@ final class ConditionalCacheDecoratorsPass implements CompilerPassInterface
     public function process(ContainerBuilder $container): void
     {
         // Only proceed if cache decorators are enabled
-        if (!$container->hasParameter('zhortein_multi_tenant.decorators.cache.enabled') ||
-            !$container->getParameter('zhortein_multi_tenant.decorators.cache.enabled')) {
+        if (!$container->hasParameter('zhortein_multi_tenant.decorators.cache.enabled')
+            || !$container->getParameter('zhortein_multi_tenant.decorators.cache.enabled')) {
             return;
         }
 

--- a/src/DependencyInjection/ZhorteinMultiTenantExtension.php
+++ b/src/DependencyInjection/ZhorteinMultiTenantExtension.php
@@ -22,7 +22,6 @@ use Zhortein\MultiTenantBundle\Context\TenantContext;
 use Zhortein\MultiTenantBundle\Context\TenantContextInterface;
 use Zhortein\MultiTenantBundle\Database\TenantSessionConfigurator;
 use Zhortein\MultiTenantBundle\Decorator\TenantAwareCacheDecorator;
-use Zhortein\MultiTenantBundle\Decorator\TenantAwareSimpleCacheDecorator;
 use Zhortein\MultiTenantBundle\Decorator\TenantLoggerProcessor;
 use Zhortein\MultiTenantBundle\Decorator\TenantStoragePathHelper;
 use Zhortein\MultiTenantBundle\Doctrine\DefaultConnectionResolver;
@@ -517,7 +516,7 @@ final class ZhorteinMultiTenantExtension extends Extension
     private function registerMailerServices(ContainerBuilder $container): void
     {
         // Only register mailer services if Symfony Mailer is available
-        if (!class_exists('Symfony\Component\Mailer\MailerInterface')) {
+        if (!interface_exists('Symfony\Component\Mailer\MailerInterface')) {
             return;
         }
 
@@ -543,7 +542,7 @@ final class ZhorteinMultiTenantExtension extends Extension
     private function registerMessengerServices(ContainerBuilder $container): void
     {
         // Only register messenger services if Symfony Messenger is available
-        if (!class_exists('Symfony\Component\Messenger\MessageBusInterface')) {
+        if (!interface_exists('Symfony\Component\Messenger\MessageBusInterface')) {
             return;
         }
 

--- a/src/Doctrine/TenantAwareConnectionFactory.php
+++ b/src/Doctrine/TenantAwareConnectionFactory.php
@@ -56,6 +56,7 @@ final readonly class TenantAwareConnectionFactory
             unset($params['url']); // Remove URL after parsing
         }
 
+        // @phpstan-ignore-next-line
         return DriverManager::getConnection($params, $this->configuration);
     }
 }

--- a/src/Doctrine/TenantEntityManagerFactory.php
+++ b/src/Doctrine/TenantEntityManagerFactory.php
@@ -36,6 +36,7 @@ final readonly class TenantEntityManagerFactory
     public function createForTenant(TenantInterface $tenant): EntityManagerInterface
     {
         $connectionParams = $this->connectionResolver->resolveParameters($tenant);
+        // @phpstan-ignore-next-line
         $connection = DriverManager::getConnection($connectionParams);
 
         return new EntityManager($connection, $this->ormConfiguration);

--- a/src/Resolver/PathTenantResolver.php
+++ b/src/Resolver/PathTenantResolver.php
@@ -15,6 +15,9 @@ use Zhortein\MultiTenantBundle\Entity\TenantInterface;
  */
 final readonly class PathTenantResolver implements TenantResolverInterface
 {
+    /**
+     * @param class-string<TenantInterface> $tenantEntityClass
+     */
     public function __construct(
         private EntityManagerInterface $em,
         private string $tenantEntityClass,

--- a/src/Resolver/SubdomainTenantResolver.php
+++ b/src/Resolver/SubdomainTenantResolver.php
@@ -20,7 +20,8 @@ final class SubdomainTenantResolver implements TenantResolverInterface
     private const array EXCLUDED_SUBDOMAINS = ['www', 'api', 'admin', 'mail', 'ftp'];
 
     /**
-     * @param string[] $excludedSubdomains Common subdomains to exclude from tenant resolution
+     * @param class-string<TenantInterface> $tenantEntityClass  Tenant entity class
+     * @param string[]                      $excludedSubdomains Common subdomains to exclude from tenant resolution
      */
     public function __construct(
         private readonly EntityManagerInterface $em,

--- a/tests/Dockerfile.rls
+++ b/tests/Dockerfile.rls
@@ -1,0 +1,8 @@
+FROM php:8.3-cli
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libpq-dev \
+    && docker-php-ext-install pdo_pgsql \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app

--- a/tests/Functional/Database/RlsIntegrationTest.php
+++ b/tests/Functional/Database/RlsIntegrationTest.php
@@ -7,6 +7,7 @@ namespace Zhortein\MultiTenantBundle\Tests\Functional\Database;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use PHPUnit\Framework\TestCase;
 use Zhortein\MultiTenantBundle\Context\TenantContext;
 use Zhortein\MultiTenantBundle\Database\TenantSessionConfigurator;
@@ -222,7 +223,7 @@ final class RlsIntegrationTest extends TestCase
 
         // Clear tenant context (no session variable set)
         $this->tenantContext->clear();
-        $this->connection->executeStatement('SELECT set_config(?, NULL, true)', ['app.tenant_id']);
+        $this->connection->executeStatement('SELECT set_config(?, ?, false)', ['app.tenant_id', '']);
 
         // Query should return no results due to RLS policy
         $products = $this->connection->fetchAllAssociative('SELECT * FROM test_products');
@@ -231,7 +232,7 @@ final class RlsIntegrationTest extends TestCase
 
     private function isPostgreSQL(): bool
     {
-        return str_contains($this->connection->getDatabasePlatform()->getName(), 'postgresql');
+        return $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform;
     }
 
     private function setupTestData(): void
@@ -294,7 +295,7 @@ final class RlsIntegrationTest extends TestCase
         $tenant = $this->tenantContext->getTenant();
         if (null !== $tenant) {
             $this->connection->executeStatement(
-                'SELECT set_config(?, ?, true)',
+                'SELECT set_config(?, ?, false)',
                 ['app.tenant_id', (string) $tenant->getId()]
             );
         }
@@ -313,6 +314,7 @@ final class RlsIntegrationTest extends TestCase
             'password' => $_ENV['TEST_DATABASE_PASSWORD'] ?? 'postgres',
         ];
 
+        // @phpstan-ignore-next-line
         return DriverManager::getConnection($connectionParams);
     }
 

--- a/tests/Integration/RlsIsolationTest.php
+++ b/tests/Integration/RlsIsolationTest.php
@@ -4,301 +4,285 @@ declare(strict_types=1);
 
 namespace Zhortein\MultiTenantBundle\Tests\Integration;
 
-use Zhortein\MultiTenantBundle\Tests\Fixtures\Entity\TestProduct;
-use Zhortein\MultiTenantBundle\Tests\Toolkit\TenantWebTestCase;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception;
+use PHPUnit\Framework\TestCase;
+use Zhortein\MultiTenantBundle\Context\TenantContext;
+use Zhortein\MultiTenantBundle\Database\TenantSessionConfigurator;
+use Zhortein\MultiTenantBundle\Registry\InMemoryTenantRegistry;
+use Zhortein\MultiTenantBundle\Tests\Fixtures\Entity\TestTenant;
 
 /**
- * Integration test for PostgreSQL Row-Level Security (RLS) isolation.
+ * Proves PostgreSQL RLS isolation through raw DBAL queries.
  *
- * This test verifies that:
- * 1. Doctrine filters work correctly for tenant isolation
- * 2. PostgreSQL RLS provides defense-in-depth even when Doctrine filters are disabled
- * 3. Tenant context properly sets PostgreSQL session variables
+ * The dedicated Compose target runs this class against PostgreSQL 16 with a
+ * real pdo_pgsql connection. FORCE ROW LEVEL SECURITY ensures the table owner
+ * cannot bypass the policy, and raw SQL keeps the proof independent from the
+ * Doctrine tenant filter.
  */
-class RlsIsolationTest extends TenantWebTestCase
+final class RlsIsolationTest extends TestCase
 {
-    private const TENANT_A_SLUG = 'tenant-a';
-    private const TENANT_B_SLUG = 'tenant-b';
-    private const TENANT_A_PRODUCTS = 2;
-    private const TENANT_B_PRODUCTS = 1;
+    private const int TENANT_A_ID = 1;
+    private const int TENANT_B_ID = 2;
+
+    private Connection $adminConnection;
+    private Connection $connection;
+    private TenantContext $tenantContext;
+    private TenantSessionConfigurator $sessionConfigurator;
+    private TestTenant $tenantA;
+    private TestTenant $tenantB;
 
     protected function setUp(): void
     {
-        parent::setUp();
+        try {
+            $this->adminConnection = DriverManager::getConnection($this->connectionParameters(
+                $_ENV['TEST_DATABASE_USER'] ?? 'test_user',
+                $_ENV['TEST_DATABASE_PASSWORD'] ?? 'test_password',
+            ));
+            $this->adminConnection->executeQuery('SELECT 1');
+            $this->createSchemaAndSeedData();
+            $this->connection = DriverManager::getConnection($this->connectionParameters(
+                $_ENV['TEST_DATABASE_APP_USER'] ?? 'rls_test_app',
+                $_ENV['TEST_DATABASE_APP_PASSWORD'] ?? 'rls_test_password',
+            ));
+            $this->connection->executeQuery('SELECT 1');
+        } catch (\Throwable $exception) {
+            if ('1' === ($_ENV['TEST_DATABASE_REQUIRED'] ?? null)) {
+                throw new \RuntimeException('The required PostgreSQL RLS environment is unavailable.', 0, $exception);
+            }
 
-        // Create test tenants
-        $this->getTestData()->seedTenants([
-            self::TENANT_A_SLUG => ['name' => 'Tenant A'],
-            self::TENANT_B_SLUG => ['name' => 'Tenant B'],
+            $this->markTestSkipped('PostgreSQL is not available; run `make test-with-postgres` for mandatory RLS coverage.');
+        }
+
+        $this->tenantA = $this->createTenant(self::TENANT_A_ID, 'tenant-a', 'Tenant A');
+        $this->tenantB = $this->createTenant(self::TENANT_B_ID, 'tenant-b', 'Tenant B');
+
+        $registry = new InMemoryTenantRegistry();
+        $registry->addTenant($this->tenantA);
+        $registry->addTenant($this->tenantB);
+
+        $this->tenantContext = new TenantContext();
+        $this->sessionConfigurator = new TenantSessionConfigurator(
+            $this->tenantContext,
+            $this->connection,
+            $registry,
+            true,
+            'app.tenant_id',
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->connection) && $this->connection->isConnected()) {
+            $this->tenantContext->clear();
+            $this->sessionConfigurator->setConfig();
+            $this->connection->close();
+        }
+        if (isset($this->adminConnection) && $this->adminConnection->isConnected()) {
+            $this->adminConnection->executeStatement('DROP TABLE IF EXISTS test_products');
+            $this->adminConnection->executeStatement('DROP TABLE IF EXISTS test_tenants');
+            $this->adminConnection->close();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testPolicyIsEnabledAndForcedForTheTableOwner(): void
+    {
+        $state = $this->connection->fetchAssociative(<<<'SQL'
+            SELECT relrowsecurity, relforcerowsecurity
+            FROM pg_class
+            WHERE oid = 'test_products'::regclass
+            SQL);
+
+        self::assertIsArray($state);
+        self::assertTrue($state['relrowsecurity']);
+        self::assertTrue($state['relforcerowsecurity']);
+        self::assertSame(1, (int) $this->connection->fetchOne(<<<'SQL'
+            SELECT count(*)
+            FROM pg_policies
+            WHERE schemaname = 'public'
+              AND tablename = 'test_products'
+              AND policyname = 'tenant_isolation_policy'
+            SQL));
+    }
+
+    public function testSameTenantReadsAreAllowedAndCrossTenantReadsAreDenied(): void
+    {
+        $this->configureTenant($this->tenantA);
+
+        $rows = $this->connection->fetchAllAssociative('SELECT tenant_id, name FROM test_products ORDER BY id');
+
+        self::assertCount(2, $rows, 'Tenant A must see both of its own rows.');
+        self::assertSame([self::TENANT_A_ID], array_values(array_unique(array_map(
+            static fn (array $row): int => (int) $row['tenant_id'],
+            $rows,
+        ))));
+        self::assertNotContains('Tenant B secret', array_column($rows, 'name'));
+    }
+
+    public function testTenantSwitchReplacesTheVisibleDataset(): void
+    {
+        $this->configureTenant($this->tenantA);
+        self::assertSame(['Tenant A product 1', 'Tenant A product 2'], $this->visibleProductNames());
+
+        $this->configureTenant($this->tenantB);
+        self::assertSame(['Tenant B secret'], $this->visibleProductNames());
+        self::assertNotContains('Tenant A product 1', $this->visibleProductNames());
+    }
+
+    public function testNativeSqlRemainsIsolatedWithoutTheDoctrineTenantFilter(): void
+    {
+        $this->configureTenant($this->tenantB);
+
+        $rows = $this->connection->executeQuery(
+            'SELECT tenant_id, name FROM test_products WHERE tenant_id IN (?, ?) ORDER BY id',
+            [self::TENANT_A_ID, self::TENANT_B_ID],
+        )->fetchAllAssociative();
+
+        self::assertSame([
+            ['tenant_id' => self::TENANT_B_ID, 'name' => 'Tenant B secret'],
+        ], array_map(
+            static fn (array $row): array => ['tenant_id' => (int) $row['tenant_id'], 'name' => $row['name']],
+            $rows,
+        ));
+    }
+
+    public function testWritesAllowTheCurrentTenantAndRejectAnotherTenant(): void
+    {
+        $this->configureTenant($this->tenantA);
+
+        $this->connection->insert('test_products', [
+            'tenant_id' => self::TENANT_A_ID,
+            'name' => 'Tenant A allowed insert',
+            'price' => '15.00',
         ]);
+        self::assertContains('Tenant A allowed insert', $this->visibleProductNames());
 
-        // Seed test data
-        $this->getTestData()->seedProducts(self::TENANT_A_SLUG, self::TENANT_A_PRODUCTS);
-        $this->getTestData()->seedProducts(self::TENANT_B_SLUG, self::TENANT_B_PRODUCTS);
+        try {
+            $this->connection->insert('test_products', [
+                'tenant_id' => self::TENANT_B_ID,
+                'name' => 'Cross-tenant attack',
+                'price' => '99.00',
+            ]);
+            self::fail('PostgreSQL RLS must reject a write targeting another tenant.');
+        } catch (Exception $exception) {
+            self::assertStringContainsString('row-level security policy', $exception->getMessage());
+        }
+
+        self::assertNotContains('Cross-tenant attack', $this->visibleProductNames());
     }
 
-    /**
-     * Test Case #1: Doctrine filter ON - should see only tenant-specific data.
-     */
-    public function testDoctrineFilterIsolation(): void
+    public function testMissingContextFailsClosedAndSessionStateIsCleared(): void
     {
-        $productRepository = $this->getEntityManager()->getRepository(TestProduct::class);
+        $this->configureTenant($this->tenantA);
+        self::assertSame((string) self::TENANT_A_ID, $this->currentTenantSetting());
+        self::assertNotEmpty($this->visibleProductNames());
 
-        // Test tenant A context
-        $this->withTenant(self::TENANT_A_SLUG, function () use ($productRepository) {
-            $products = $productRepository->findAll();
-            $this->assertCount(
-                self::TENANT_A_PRODUCTS,
-                $products,
-                'Tenant A should see exactly '.self::TENANT_A_PRODUCTS.' products'
-            );
+        $this->tenantContext->clear();
+        $this->sessionConfigurator->setConfig();
 
-            foreach ($products as $product) {
-                $this->assertStringContainsString(
-                    self::TENANT_A_SLUG,
-                    $product->getName(),
-                    'All products should belong to tenant A'
-                );
-            }
-        });
-
-        // Test tenant B context
-        $this->withTenant(self::TENANT_B_SLUG, function () use ($productRepository) {
-            $products = $productRepository->findAll();
-            $this->assertCount(
-                self::TENANT_B_PRODUCTS,
-                $products,
-                'Tenant B should see exactly '.self::TENANT_B_PRODUCTS.' product'
-            );
-
-            foreach ($products as $product) {
-                $this->assertStringContainsString(
-                    self::TENANT_B_SLUG,
-                    $product->getName(),
-                    'All products should belong to tenant B'
-                );
-            }
-        });
+        self::assertSame('', $this->currentTenantSetting());
+        self::assertSame([], $this->visibleProductNames(), 'No tenant context must expose no tenant-owned rows.');
     }
 
-    /**
-     * Test Case #2: Doctrine filter OFF + RLS ON - PostgreSQL RLS should still provide isolation.
-     *
-     * This is the critical test that proves RLS works as defense-in-depth.
-     * Even with Doctrine filters disabled, PostgreSQL should only return tenant-specific data.
-     */
-    public function testRlsIsolationWithDoctrineFilterDisabled(): void
+    private function createSchemaAndSeedData(): void
     {
-        $productRepository = $this->getEntityManager()->getRepository(TestProduct::class);
-
-        // Test tenant A context with Doctrine filter disabled
-        $this->withTenant(self::TENANT_A_SLUG, function () use ($productRepository) {
-            $this->withoutDoctrineTenantFilter(function () use ($productRepository) {
-                // Even with Doctrine filter disabled, RLS should limit results to tenant A
-                $products = $productRepository->findAll();
-
-                $this->assertCount(
-                    self::TENANT_A_PRODUCTS,
-                    $products,
-                    'RLS should ensure tenant A sees only '.self::TENANT_A_PRODUCTS.' products (not all '.(self::TENANT_A_PRODUCTS + self::TENANT_B_PRODUCTS).')'
-                );
-
-                foreach ($products as $product) {
-                    $this->assertStringContainsString(
-                        self::TENANT_A_SLUG,
-                        $product->getName(),
-                        'RLS should ensure all products belong to tenant A'
-                    );
-                }
-            });
-        });
-
-        // Test tenant B context with Doctrine filter disabled
-        $this->withTenant(self::TENANT_B_SLUG, function () use ($productRepository) {
-            $this->withoutDoctrineTenantFilter(function () use ($productRepository) {
-                // Even with Doctrine filter disabled, RLS should limit results to tenant B
-                $products = $productRepository->findAll();
-
-                $this->assertCount(
-                    self::TENANT_B_PRODUCTS,
-                    $products,
-                    'RLS should ensure tenant B sees only '.self::TENANT_B_PRODUCTS.' product (not all '.(self::TENANT_A_PRODUCTS + self::TENANT_B_PRODUCTS).')'
-                );
-
-                foreach ($products as $product) {
-                    $this->assertStringContainsString(
-                        self::TENANT_B_SLUG,
-                        $product->getName(),
-                        'RLS should ensure all products belong to tenant B'
-                    );
-                }
-            });
-        });
+        $this->adminConnection->executeStatement(<<<'SQL'
+            DO $$
+            BEGIN
+                IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'rls_test_app') THEN
+                    CREATE ROLE rls_test_app LOGIN PASSWORD 'rls_test_password' NOSUPERUSER NOCREATEDB NOCREATEROLE;
+                END IF;
+            END
+            $$
+            SQL);
+        $this->adminConnection->executeStatement('DROP TABLE IF EXISTS test_products');
+        $this->adminConnection->executeStatement('DROP TABLE IF EXISTS test_tenants');
+        $this->adminConnection->executeStatement(<<<'SQL'
+            CREATE TABLE test_tenants (
+                id INTEGER PRIMARY KEY,
+                slug VARCHAR(255) NOT NULL UNIQUE,
+                name VARCHAR(255) NOT NULL
+            )
+            SQL);
+        $this->adminConnection->executeStatement(<<<'SQL'
+            CREATE TABLE test_products (
+                id SERIAL PRIMARY KEY,
+                tenant_id INTEGER NOT NULL REFERENCES test_tenants(id),
+                name VARCHAR(255) NOT NULL,
+                price NUMERIC(10, 2) NOT NULL
+            )
+            SQL);
+        $this->adminConnection->executeStatement(<<<'SQL'
+            INSERT INTO test_tenants (id, slug, name)
+            VALUES (1, 'tenant-a', 'Tenant A'), (2, 'tenant-b', 'Tenant B')
+            SQL);
+        $this->adminConnection->executeStatement(<<<'SQL'
+            INSERT INTO test_products (tenant_id, name, price)
+            VALUES
+                (1, 'Tenant A product 1', 10.00),
+                (1, 'Tenant A product 2', 20.00),
+                (2, 'Tenant B secret', 30.00)
+            SQL);
+        $this->adminConnection->executeStatement('ALTER TABLE test_products ENABLE ROW LEVEL SECURITY');
+        $this->adminConnection->executeStatement('ALTER TABLE test_products FORCE ROW LEVEL SECURITY');
+        $this->adminConnection->executeStatement(<<<'SQL'
+            CREATE POLICY tenant_isolation_policy ON test_products
+            FOR ALL
+            USING (tenant_id = NULLIF(current_setting('app.tenant_id', true), '')::integer)
+            WITH CHECK (tenant_id = NULLIF(current_setting('app.tenant_id', true), '')::integer)
+            SQL);
+        $this->adminConnection->executeStatement('GRANT USAGE ON SCHEMA public TO rls_test_app');
+        $this->adminConnection->executeStatement('GRANT SELECT ON test_tenants TO rls_test_app');
+        $this->adminConnection->executeStatement('GRANT SELECT, INSERT, UPDATE, DELETE ON test_products TO rls_test_app');
+        $this->adminConnection->executeStatement('GRANT USAGE, SELECT ON SEQUENCE test_products_id_seq TO rls_test_app');
     }
 
-    /**
-     * Test that raw DQL queries also respect RLS isolation.
-     */
-    public function testRlsIsolationWithDqlQueries(): void
+    private function configureTenant(TestTenant $tenant): void
     {
-        $entityManager = $this->getEntityManager();
-
-        // Test tenant A context
-        $this->withTenant(self::TENANT_A_SLUG, function () use ($entityManager) {
-            $this->withoutDoctrineTenantFilter(function () use ($entityManager) {
-                $query = $entityManager->createQuery(
-                    'SELECT p FROM '.TestProduct::class.' p ORDER BY p.id'
-                );
-
-                $products = $query->getResult();
-
-                $this->assertCount(
-                    self::TENANT_A_PRODUCTS,
-                    $products,
-                    'RLS should limit DQL query results to tenant A products only'
-                );
-
-                foreach ($products as $product) {
-                    $this->assertStringContainsString(
-                        self::TENANT_A_SLUG,
-                        $product->getName(),
-                        'All DQL query results should belong to tenant A'
-                    );
-                }
-            });
-        });
-
-        // Test tenant B context
-        $this->withTenant(self::TENANT_B_SLUG, function () use ($entityManager) {
-            $this->withoutDoctrineTenantFilter(function () use ($entityManager) {
-                $query = $entityManager->createQuery(
-                    'SELECT p FROM '.TestProduct::class.' p ORDER BY p.id'
-                );
-
-                $products = $query->getResult();
-
-                $this->assertCount(
-                    self::TENANT_B_PRODUCTS,
-                    $products,
-                    'RLS should limit DQL query results to tenant B products only'
-                );
-
-                foreach ($products as $product) {
-                    $this->assertStringContainsString(
-                        self::TENANT_B_SLUG,
-                        $product->getName(),
-                        'All DQL query results should belong to tenant B'
-                    );
-                }
-            });
-        });
+        $this->tenantContext->setTenant($tenant);
+        $this->sessionConfigurator->setConfig();
+        self::assertSame((string) $tenant->getId(), $this->currentTenantSetting());
     }
 
-    /**
-     * Test that native SQL queries also respect RLS isolation.
-     */
-    public function testRlsIsolationWithNativeSqlQueries(): void
+    /** @return list<string> */
+    private function visibleProductNames(): array
     {
-        $connection = $this->getEntityManager()->getConnection();
-
-        // Test tenant A context
-        $this->withTenant(self::TENANT_A_SLUG, function () use ($connection) {
-            $this->withoutDoctrineTenantFilter(function () use ($connection) {
-                $result = $connection->executeQuery('SELECT * FROM test_products ORDER BY id');
-                $products = $result->fetchAllAssociative();
-
-                $this->assertCount(
-                    self::TENANT_A_PRODUCTS,
-                    $products,
-                    'RLS should limit native SQL query results to tenant A products only'
-                );
-
-                foreach ($products as $product) {
-                    $this->assertStringContainsString(
-                        self::TENANT_A_SLUG,
-                        $product['name'],
-                        'All native SQL query results should belong to tenant A'
-                    );
-                }
-            });
-        });
-
-        // Test tenant B context
-        $this->withTenant(self::TENANT_B_SLUG, function () use ($connection) {
-            $this->withoutDoctrineTenantFilter(function () use ($connection) {
-                $result = $connection->executeQuery('SELECT * FROM test_products ORDER BY id');
-                $products = $result->fetchAllAssociative();
-
-                $this->assertCount(
-                    self::TENANT_B_PRODUCTS,
-                    $products,
-                    'RLS should limit native SQL query results to tenant B products only'
-                );
-
-                foreach ($products as $product) {
-                    $this->assertStringContainsString(
-                        self::TENANT_B_SLUG,
-                        $product['name'],
-                        'All native SQL query results should belong to tenant B'
-                    );
-                }
-            });
-        });
+        return array_values(array_map(
+            static fn (array $row): string => (string) $row['name'],
+            $this->connection->fetchAllAssociative('SELECT name FROM test_products ORDER BY id'),
+        ));
     }
 
-    /**
-     * Test that PostgreSQL session variable is properly set and cleared.
-     */
-    public function testPostgreSqlSessionVariableManagement(): void
+    private function currentTenantSetting(): string
     {
-        $connection = $this->getEntityManager()->getConnection();
-
-        // Initially, no tenant should be set
-        $result = $connection->executeQuery("SELECT current_setting('app.tenant_id', true)");
-        $currentTenantId = $result->fetchOne();
-        $this->assertEmpty($currentTenantId, 'Initially, no tenant ID should be set');
-
-        // Test that session variable is set within tenant context
-        $tenantA = $this->getTenantRegistry()->findBySlug(self::TENANT_A_SLUG);
-        $this->assertNotNull($tenantA);
-
-        $this->withTenant(self::TENANT_A_SLUG, function () use ($connection, $tenantA) {
-            $result = $connection->executeQuery("SELECT current_setting('app.tenant_id', true)");
-            $currentTenantId = $result->fetchOne();
-            $this->assertSame(
-                (string) $tenantA->getId(),
-                $currentTenantId,
-                'Session variable should be set to tenant A ID'
-            );
-        });
-
-        // After exiting tenant context, session variable should be cleared
-        $result = $connection->executeQuery("SELECT current_setting('app.tenant_id', true)");
-        $currentTenantId = $result->fetchOne();
-        $this->assertEmpty($currentTenantId, 'Session variable should be cleared after exiting tenant context');
+        return (string) $this->connection->fetchOne("SELECT current_setting('app.tenant_id', true)");
     }
 
-    /**
-     * Test nested tenant contexts.
-     */
-    public function testNestedTenantContexts(): void
+    /** @return array{driver: string, host: string, port: int, dbname: string, user: string, password: string} */
+    private function connectionParameters(string $user, string $password): array
     {
-        $productRepository = $this->getEntityManager()->getRepository(TestProduct::class);
+        return [
+            'driver' => 'pdo_pgsql',
+            'host' => $_ENV['TEST_DATABASE_HOST'] ?? '127.0.0.1',
+            'port' => (int) ($_ENV['TEST_DATABASE_PORT'] ?? 5432),
+            'dbname' => $_ENV['TEST_DATABASE_NAME'] ?? 'multi_tenant_test',
+            'user' => $user,
+            'password' => $password,
+        ];
+    }
 
-        $this->withTenant(self::TENANT_A_SLUG, function () use ($productRepository) {
-            // In tenant A context
-            $productsA = $productRepository->findAll();
-            $this->assertCount(self::TENANT_A_PRODUCTS, $productsA);
+    private function createTenant(int $id, string $slug, string $name): TestTenant
+    {
+        $tenant = new TestTenant();
+        $property = new \ReflectionProperty($tenant, 'id');
+        $property->setValue($tenant, $id);
+        $tenant->setSlug($slug);
+        $tenant->setName($name);
+        $tenant->setActive(true);
 
-            $this->withTenant(self::TENANT_B_SLUG, function () use ($productRepository) {
-                // In nested tenant B context
-                $productsB = $productRepository->findAll();
-                $this->assertCount(self::TENANT_B_PRODUCTS, $productsB);
-            });
-
-            // Back in tenant A context
-            $productsA2 = $productRepository->findAll();
-            $this->assertCount(self::TENANT_A_PRODUCTS, $productsA2);
-        });
+        return $tenant;
     }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -116,11 +116,14 @@ public function testCommandWithTenant(): void
 ### Integration Tests
 
 #### RlsIsolationTest ⭐
-**The most critical test** - proves PostgreSQL RLS works as defense-in-depth:
-- Doctrine filter ON: Normal tenant isolation
-- **Doctrine filter OFF + RLS ON**: Critical test proving RLS isolation
-- DQL and native SQL query isolation
-- PostgreSQL session variable management
+
+The dedicated suite proves PostgreSQL RLS as a database-level defense:
+
+- PostgreSQL 16 runs in Docker Compose with a PHP 8.3 image containing `pdo_pgsql`.
+- Schema creation and fixtures use the administrative test role.
+- Every isolation assertion uses a separate non-superuser application role, because PostgreSQL superusers bypass RLS even when a table uses `FORCE ROW LEVEL SECURITY`.
+- Raw DBAL queries prove same-tenant reads and writes, denied cross-tenant reads and writes, tenant switching, and fail-closed behavior without relying on the Doctrine tenant filter.
+- `TEST_DATABASE_REQUIRED=1` turns environment failures into test failures in the dedicated target instead of skipped tests.
 
 #### ResolverChainHttpTest
 - Subdomain, header, path, query, and domain resolution
@@ -152,18 +155,12 @@ public function testCommandWithTenant(): void
 ### Using Docker Compose
 
 ```bash
-# Start PostgreSQL for testing
-cd tests && docker-compose up -d postgres
-
-# Wait for PostgreSQL to be ready
-docker-compose exec postgres pg_isready -U test_user -d multi_tenant_test
-
-# Connect to PostgreSQL shell
-docker-compose exec postgres psql -U test_user -d multi_tenant_test
-
-# Stop PostgreSQL
-docker-compose down
+# Build the PHP image, start PostgreSQL 16, run all mandatory RLS assertions,
+# and stop the environment even when a test fails.
+make test-with-postgres
 ```
+
+The Compose environment creates the privileged `test_user` only for schema setup. The test itself creates and connects as `rls_test_app`, a non-superuser role with limited DML permissions. Do not run isolation assertions as `POSTGRES_USER`; that role is a PostgreSQL superuser and bypasses RLS.
 
 ### Manual Setup
 
@@ -300,10 +297,10 @@ PostgreSQL session variables are automatically managed:
 
 ```sql
 -- Set tenant context
-SELECT set_config('app.tenant_id', '1', true);
+SELECT set_config('app.tenant_id', '1', false);
 
 -- Clear tenant context
-SELECT set_config('app.tenant_id', NULL, true);
+SELECT set_config('app.tenant_id', '', false);
 ```
 
 ## 🚀 CI/CD Integration
@@ -364,26 +361,26 @@ When adding new tests to the Test Kit:
 
 ```bash
 # Check if PostgreSQL is running
-docker-compose ps
+docker compose ps
 
 # Check PostgreSQL logs
-docker-compose logs postgres
+docker compose logs postgres
 
 # Test connection manually
-docker-compose exec postgres pg_isready -U test_user -d multi_tenant_test
+docker compose exec postgres pg_isready -U test_user -d multi_tenant_test
 ```
 
 ### RLS Issues
 
 ```bash
 # Check if RLS is enabled
-docker-compose exec postgres psql -U test_user -d multi_tenant_test -c "SELECT relrowsecurity FROM pg_class WHERE relname = 'test_products';"
+docker compose exec postgres psql -U test_user -d multi_tenant_test -c "SELECT relrowsecurity FROM pg_class WHERE relname = 'test_products';"
 
 # Check RLS policies
-docker-compose exec postgres psql -U test_user -d multi_tenant_test -c "SELECT * FROM pg_policies WHERE tablename = 'test_products';"
+docker compose exec postgres psql -U test_user -d multi_tenant_test -c "SELECT * FROM pg_policies WHERE tablename = 'test_products';"
 
 # Reinitialize database
-docker-compose exec postgres psql -U test_user -d multi_tenant_test -f /docker-entrypoint-initdb.d/init.sql
+docker compose exec postgres psql -U test_user -d multi_tenant_test -f /docker-entrypoint-initdb.d/init.sql
 ```
 
 ### Test Failures

--- a/tests/Toolkit/WithTenantTrait.php
+++ b/tests/Toolkit/WithTenantTrait.php
@@ -170,7 +170,7 @@ trait WithTenantTrait
     private function setPostgreSQLTenantId(Connection $connection, string $tenantId): void
     {
         $connection->executeStatement(
-            'SELECT set_config(?, ?, true)',
+            'SELECT set_config(?, ?, false)',
             ['app.tenant_id', $tenantId]
         );
     }
@@ -183,8 +183,8 @@ trait WithTenantTrait
     private function clearPostgreSQLTenantId(Connection $connection): void
     {
         $connection->executeStatement(
-            'SELECT set_config(?, NULL, true)',
-            ['app.tenant_id']
+            'SELECT set_config(?, ?, false)',
+            ['app.tenant_id', '']
         );
     }
 

--- a/tests/Unit/Command/SyncRlsPoliciesCommandTest.php
+++ b/tests/Unit/Command/SyncRlsPoliciesCommandTest.php
@@ -56,7 +56,6 @@ final class SyncRlsPoliciesCommandTest extends TestCase
     public function testExecuteWithNonPostgreSQLDatabase(): void
     {
         $platform = $this->createMock(\Doctrine\DBAL\Platforms\MySQLPlatform::class);
-        $platform->method('getName')->willReturn('mysql');
 
         $this->connection
             ->method('getDatabasePlatform')
@@ -189,7 +188,7 @@ final class SyncRlsPoliciesCommandTest extends TestCase
             ->willReturnCallback(function ($sql) use (&$expectedCalls) {
                 $this->assertContains($sql, $expectedCalls);
 
-                return null;
+                return 1;
             });
 
         $exitCode = $this->commandTester->execute(['--apply' => true]);
@@ -278,7 +277,7 @@ final class SyncRlsPoliciesCommandTest extends TestCase
         // Mock connection methods to throw exception
         $this->connection
             ->method('fetchOne')
-            ->willThrowException(new Exception('Database error'));
+            ->willThrowException($this->createMock(Exception::class));
 
         $this->connection
             ->method('quoteIdentifier')

--- a/tests/Unit/Database/TenantSessionConfiguratorTest.php
+++ b/tests/Unit/Database/TenantSessionConfiguratorTest.php
@@ -78,7 +78,7 @@ final class TenantSessionConfiguratorTest extends TestCase
         $this->configurator->onKernelRequest($event);
     }
 
-    public function testOnKernelRequestSkipsWhenNoTenant(): void
+    public function testOnKernelRequestClearsSessionWhenNoTenant(): void
     {
         $event = $this->createRequestEvent(true);
 
@@ -86,14 +86,29 @@ final class TenantSessionConfiguratorTest extends TestCase
             ->method('getTenant')
             ->willReturn(null);
 
+        $messages = [];
         $this->logger
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('debug')
-            ->with('No tenant context available for RLS configuration');
+            ->willReturnCallback(static function (string $message) use (&$messages): void {
+                $messages[] = $message;
+            });
 
-        $this->connection->expects($this->never())->method('executeStatement');
+        $this->connection
+            ->method('getDatabasePlatform')
+            ->willReturn(new PostgreSQLPlatform());
+
+        $this->connection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with('SELECT set_config(?, ?, false)', ['app.tenant_id', '']);
 
         $this->configurator->onKernelRequest($event);
+
+        $this->assertSame([
+            'No tenant context available for RLS configuration',
+            'Cleared PostgreSQL session variable for RLS',
+        ], $messages);
     }
 
     public function testOnKernelRequestSkipsWhenNotPostgreSQL(): void
@@ -106,7 +121,6 @@ final class TenantSessionConfiguratorTest extends TestCase
             ->willReturn($tenant);
 
         $platform = $this->createMock(\Doctrine\DBAL\Platforms\MySQLPlatform::class);
-        $platform->method('getName')->willReturn('mysql');
 
         $this->connection
             ->method('getDatabasePlatform')
@@ -140,7 +154,7 @@ final class TenantSessionConfiguratorTest extends TestCase
             ->expects($this->once())
             ->method('executeStatement')
             ->with(
-                'SELECT set_config(?, ?, true)',
+                'SELECT set_config(?, ?, false)',
                 ['app.tenant_id', '123']
             );
 
@@ -173,7 +187,7 @@ final class TenantSessionConfiguratorTest extends TestCase
             ->method('getDatabasePlatform')
             ->willReturn($platform);
 
-        $exception = new Exception('Database error');
+        $exception = new class('Database error') extends \Exception implements Exception {};
         $this->connection
             ->method('executeStatement')
             ->willThrowException($exception);
@@ -241,8 +255,8 @@ final class TenantSessionConfiguratorTest extends TestCase
             ->willReturn($platform);
 
         $expectedCalls = [
-            ['SELECT set_config(?, ?, true)', ['app.tenant_id', '456']],
-            ['SELECT set_config(?, NULL, true)', ['app.tenant_id']],
+            ['SELECT set_config(?, ?, false)', ['app.tenant_id', '456']],
+            ['SELECT set_config(?, ?, false)', ['app.tenant_id', '']],
         ];
         $callCount = 0;
 
@@ -254,7 +268,7 @@ final class TenantSessionConfiguratorTest extends TestCase
                 $this->assertSame($expectedCalls[$callCount][1], $params);
                 ++$callCount;
 
-                return null;
+                return 1;
             });
 
         $this->tenantContext
@@ -339,8 +353,8 @@ final class TenantSessionConfiguratorTest extends TestCase
         $this->connection
             ->method('executeStatement')
             ->willReturnOnConsecutiveCalls(
-                null, // First call succeeds (set config)
-                null  // Second call succeeds (clear config)
+                1, // First call succeeds (set config)
+                1  // Second call succeeds (clear config)
             );
 
         $this->tenantContext

--- a/tests/Unit/DependencyInjection/Compiler/ConditionalCacheDecoratorsPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/ConditionalCacheDecoratorsPassTest.php
@@ -6,8 +6,8 @@ namespace Zhortein\MultiTenantBundle\Tests\Unit\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Zhortein\MultiTenantBundle\DependencyInjection\Compiler\ConditionalCacheDecoratorsPass;
 use Zhortein\MultiTenantBundle\Decorator\TenantAwareSimpleCacheDecorator;
+use Zhortein\MultiTenantBundle\DependencyInjection\Compiler\ConditionalCacheDecoratorsPass;
 
 /**
  * @covers \Zhortein\MultiTenantBundle\DependencyInjection\Compiler\ConditionalCacheDecoratorsPass
@@ -73,7 +73,7 @@ final class ConditionalCacheDecoratorsPassTest extends TestCase
     {
         $this->container->setParameter('zhortein_multi_tenant.decorators.cache.enabled', true);
         $this->container->setParameter('zhortein_multi_tenant.decorators.cache.services', [123, 'cache.app']);
-        
+
         // Add the simple service
         $this->container->register('cache.app.simple');
 
@@ -96,14 +96,14 @@ final class ConditionalCacheDecoratorsPassTest extends TestCase
 
         $this->container->setParameter('zhortein_multi_tenant.decorators.cache.enabled', true);
         $this->container->setParameter('zhortein_multi_tenant.decorators.cache.services', ['cache.app']);
-        
+
         // Add the simple service
         $this->container->register('cache.app.simple');
 
         $this->compilerPass->process($this->container);
 
         $this->assertTrue($this->container->hasDefinition('cache.app.simple.tenant_aware'));
-        
+
         $definition = $this->container->getDefinition('cache.app.simple.tenant_aware');
         $this->assertSame(TenantAwareSimpleCacheDecorator::class, $definition->getClass());
         $this->assertTrue($definition->isAutowired());

--- a/tests/Unit/Resolver/SubdomainTenantResolverTest.php
+++ b/tests/Unit/Resolver/SubdomainTenantResolverTest.php
@@ -32,7 +32,8 @@ final class SubdomainTenantResolverTest extends TestCase
         $this->resolver = new SubdomainTenantResolver(
             $this->entityManager,
             'App\\Entity\\Tenant',
-            'example.com'
+            'example.com',
+            []
         );
     }
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:16-alpine
@@ -17,6 +15,25 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+
+  php-rls:
+    build:
+      context: ..
+      dockerfile: tests/Dockerfile.rls
+    working_dir: /app
+    volumes:
+      - ..:/app
+    environment:
+      TEST_DATABASE_HOST: postgres
+      TEST_DATABASE_PORT: 5432
+      TEST_DATABASE_NAME: multi_tenant_test
+      TEST_DATABASE_USER: test_user
+      TEST_DATABASE_PASSWORD: test_password
+      TEST_DATABASE_REQUIRED: 1
+    depends_on:
+      postgres:
+        condition: service_healthy
 
 volumes:
   postgres_data:

--- a/tests/validate-testkit.php
+++ b/tests/validate-testkit.php
@@ -74,7 +74,7 @@ $requiredPackages = [
 
 $composerLock = json_decode(file_get_contents(__DIR__.'/../composer.lock'), true);
 $installedPackages = [];
-foreach ($composerLock['packages'] as $package) {
+foreach (array_merge($composerLock['packages'], $composerLock['packages-dev']) as $package) {
     $installedPackages[$package['name']] = $package['version'];
 }
 
@@ -97,7 +97,7 @@ $postgresAvailable = false;
 $postgresError = '';
 
 try {
-    $dsn = $_ENV['DATABASE_URL'] ?? 'postgresql://test_user:test_password@localhost:5432/multi_tenant_test';
+    $dsn = $_ENV['DATABASE_DSN'] ?? 'pgsql:host=localhost;port=5432;dbname=multi_tenant_test;user=test_user;password=test_password';
     $pdo = new PDO($dsn);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
@@ -222,8 +222,8 @@ if ($allPassed) {
     $output->writeln('');
     $output->writeln('<comment>Common Solutions:</comment>');
     $output->writeln('  composer install                 # Install dependencies');
-    $output->writeln('  cd tests && docker-compose up -d postgres  # Start PostgreSQL');
-    $output->writeln('  docker-compose exec postgres psql -U test_user -d multi_tenant_test -f /docker-entrypoint-initdb.d/init.sql  # Setup RLS');
+    $output->writeln('  cd tests && docker compose up -d postgres  # Start PostgreSQL');
+    $output->writeln('  docker compose exec postgres psql -U test_user -d multi_tenant_test -f /docker-entrypoint-initdb.d/init.sql  # Setup RLS');
 }
 
 $output->writeln('');


### PR DESCRIPTION
## Problem

The local compatibility work targeted Symfony 7.4/8.0 and Doctrine DBAL 4, but the previous RLS quality target produced a false positive. It started PostgreSQL and selected six tests that all skipped because no test kernel was configured, then exited successfully with zero assertions. In addition, the database role was the `POSTGRES_USER` superuser, which bypasses PostgreSQL RLS, and `TenantSessionConfigurator` used transaction-local `set_config(..., true)` outside guaranteed transactions.

This relates to #6 and #14. It does not close either issue because the full CI matrix and complete documented threat model remain roadmap work.

## Solution

- Extend Composer constraints and implementation details for Symfony 7.4/8.0 and DBAL 4.
- Fix Doctrine generic class typing and optional-interface detection without lowering PHPStan strictness.
- Use session-scoped PostgreSQL tenant settings and explicitly clear stale session state when no tenant is active and after Messenger processing.
- Add a reproducible PHP 8.3 RLS image with `pdo_pgsql` and PostgreSQL 16 Compose orchestration.
- Replace the skipped kernel-dependent scenarios with six real DBAL/PostgreSQL tests.
- Separate privileged schema setup from assertions performed through a limited non-superuser application role.
- Enable and verify `FORCE ROW LEVEL SECURITY` so table ownership cannot invalidate the proof.
- Document the original false-positive state, root causes, effective coverage, and contributor commands.

## Architecture and isolation guarantees

Schema creation and fixture seeding use the administrative test connection. All security assertions use a separate `rls_test_app` role with limited DML grants. The tests use raw DBAL SQL, so their isolation result is independent from the Doctrine tenant filter.

The dedicated suite verifies:

- RLS and forced-RLS policy metadata;
- allowed same-tenant reads and writes;
- denied cross-tenant reads and writes;
- tenant A/B session switching;
- native SQL behavior with no ORM filter involved;
- fail-closed reads after the tenant session is cleared.

The dedicated target makes PostgreSQL availability mandatory and tears down Compose even after failures. The general test suite may still skip database-dependent scenarios when `pdo_pgsql` is intentionally absent; `make test-with-postgres` is the authoritative RLS gate.

## Compatibility and migration impact

- PHP remains `>=8.3`.
- Symfony support becomes `^7.4 || ^8.0`.
- No public tenant-resolution or database-strategy default changes.
- PostgreSQL RLS users gain correct session-scoped tenant state. Applications using connection pools must continue to clear tenant context at lifecycle boundaries; the bundle now clears missing and Messenger contexts explicitly.
- No Services Locaux-specific behavior is introduced.

## Validation

- `make composer-validate`
- `make composer ARGS='audit --no-interaction'` — no advisories
- `make phpstan` — level max, no errors
- `make csfixer-check`
- `make test` — 410 tests, 1,037 assertions; 263 existing notices and 76 documented skips
- `make validate-testkit`
- `make test-with-postgres` — 6 tests, 24 assertions, no skips

The repaired tests were also observed failing five isolation scenarios when executed through the PostgreSQL superuser, demonstrating that they detect an ineffective RLS execution context rather than passing superficially.