### PR TITLE
Establish the supported compatibility matrix

### DIFF
--- a/.github/workflows/test-kit.yml
+++ b/.github/workflows/test-kit.yml
@@ -45,36 +45,42 @@ jobs:
             symfony: '~7.4.0'
             orm: '~3.5.0'
             dbal: '^3.8'
+            doctrine_bundle: ^2.19
             dependencies: lowest
           - name: PHP 8.3 / Symfony 7.4 / ORM 3.6 / DBAL 4.4
             php: '8.3'
             symfony: '~7.4.0'
             orm: '^3.6'
             dbal: '^4.4'
+            doctrine_bundle: ^2.19
             dependencies: highest
           - name: PHP 8.4 / Symfony 7.4 / ORM 3.6 / DBAL 4.4
             php: '8.4'
             symfony: '~7.4.0'
             orm: '^3.6'
             dbal: '^4.4'
+            doctrine_bundle: ^3.3
             dependencies: highest
           - name: PHP 8.4 / Symfony 8.0 / ORM 3.6 / DBAL 4.4
             php: '8.4'
             symfony: '~8.0.0'
             orm: '^3.6'
             dbal: '^4.4'
+            doctrine_bundle: ^3.3
             dependencies: highest
           - name: PHP 8.5 / Symfony 7.4 / ORM 3.6 / DBAL 4.4
             php: '8.5'
             symfony: '~7.4.0'
             orm: '^3.6'
             dbal: '^4.4'
+            doctrine_bundle: ^3.3
             dependencies: highest
           - name: PHP 8.5 / Symfony 8.0 / ORM 3.6 / DBAL 4.4
             php: '8.5'
             symfony: '~8.0.0'
             orm: '^3.6'
             dbal: '^4.4'
+            doctrine_bundle: ^3.3
             dependencies: highest
 
     services:
@@ -114,11 +120,12 @@ jobs:
           coverage: none
 
       - name: Select supported dependency combination
-        run: >-
-          composer require --dev --no-update
-          "symfony/framework-bundle:${{ matrix.symfony }}"
-          "doctrine/orm:${{ matrix.orm }}"
-          "doctrine/dbal:${{ matrix.dbal }}"
+        run: |
+          composer require --no-update "doctrine/doctrine-bundle:${{ matrix.doctrine_bundle }}"
+          composer require --dev --no-update \
+            "symfony/framework-bundle:${{ matrix.symfony }}" \
+            "doctrine/orm:${{ matrix.orm }}" \
+            "doctrine/dbal:${{ matrix.dbal }}"
 
       - name: Resolve dependencies
         run: |
@@ -132,7 +139,7 @@ jobs:
         run: composer validate --strict
 
       - name: Audit dependencies
-        run: composer audit --no-interaction
+        run: composer audit --no-interaction --abandoned=report
 
       - name: Run PHPStan at maximum level
         run: vendor/bin/phpstan analyse src -c phpstan.neon --memory-limit=512M

--- a/.github/workflows/test-kit.yml
+++ b/.github/workflows/test-kit.yml
@@ -1,20 +1,82 @@
-name: Test Kit
+name: Compatibility
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
+
+permissions:
+  contents: read
 
 jobs:
-  test-kit:
-    name: Test Kit (PHP ${{ matrix.php-version }})
+  quality:
+    name: Code style
     runs-on: ubuntu-latest
-    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          dependency-versions: highest
+
+      - name: Check coding style
+        run: |
+          vendor/bin/php-cs-fixer fix src --rules=@Symfony --dry-run --diff
+          vendor/bin/php-cs-fixer fix tests --rules=@Symfony --dry-run --diff
+
+  compatibility:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        php-version: ['8.3']
-        
+        include:
+          - name: PHP 8.3 / Symfony 7.4 / ORM 3.5 / DBAL 3.8 lowest
+            php: '8.3'
+            symfony: '~7.4.0'
+            orm: '~3.5.0'
+            dbal: '^3.8'
+            dependencies: lowest
+          - name: PHP 8.3 / Symfony 7.4 / ORM 3.6 / DBAL 4.4
+            php: '8.3'
+            symfony: '~7.4.0'
+            orm: '^3.6'
+            dbal: '^4.4'
+            dependencies: highest
+          - name: PHP 8.4 / Symfony 7.4 / ORM 3.6 / DBAL 4.4
+            php: '8.4'
+            symfony: '~7.4.0'
+            orm: '^3.6'
+            dbal: '^4.4'
+            dependencies: highest
+          - name: PHP 8.4 / Symfony 8.0 / ORM 3.6 / DBAL 4.4
+            php: '8.4'
+            symfony: '~8.0.0'
+            orm: '^3.6'
+            dbal: '^4.4'
+            dependencies: highest
+          - name: PHP 8.5 / Symfony 7.4 / ORM 3.6 / DBAL 4.4
+            php: '8.5'
+            symfony: '~7.4.0'
+            orm: '^3.6'
+            dbal: '^4.4'
+            dependencies: highest
+          - name: PHP 8.5 / Symfony 8.0 / ORM 3.6 / DBAL 4.4
+            php: '8.5'
+            symfony: '~8.0.0'
+            orm: '^3.6'
+            dbal: '^4.4'
+            dependencies: highest
+
     services:
       postgres:
         image: postgres:16
@@ -23,12 +85,22 @@ jobs:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_password
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U test_user -d multi_tenant_test"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
         ports:
           - 5432:5432
+
+    env:
+      TEST_DATABASE_HOST: 127.0.0.1
+      TEST_DATABASE_PORT: 5432
+      TEST_DATABASE_NAME: multi_tenant_test
+      TEST_DATABASE_USER: test_user
+      TEST_DATABASE_PASSWORD: test_password
+      TEST_DATABASE_APP_USER: rls_test_app
+      TEST_DATABASE_APP_PASSWORD: rls_test_password
+      TEST_DATABASE_REQUIRED: 1
 
     steps:
       - name: Checkout code
@@ -37,70 +109,36 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: ${{ matrix.php }}
           extensions: pdo_pgsql, intl, json, mbstring
           coverage: none
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Select supported dependency combination
+        run: >-
+          composer require --dev --no-update
+          "symfony/framework-bundle:${{ matrix.symfony }}"
+          "doctrine/orm:${{ matrix.orm }}"
+          "doctrine/dbal:${{ matrix.dbal }}"
 
-      - name: Cache composer dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+      - name: Resolve dependencies
+        run: |
+          options=(--prefer-dist --no-progress --no-interaction --with-all-dependencies)
+          if [ "${{ matrix.dependencies }}" = "lowest" ]; then
+            options+=(--prefer-lowest)
+          fi
+          composer update "${options[@]}"
 
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest --no-interaction
-
-      - name: Validate composer.json
+      - name: Validate Composer metadata
         run: composer validate --strict
 
-      - name: Run PHPStan
+      - name: Audit dependencies
+        run: composer audit --no-interaction
+
+      - name: Run PHPStan at maximum level
         run: vendor/bin/phpstan analyse src -c phpstan.neon --memory-limit=512M
 
-      - name: Run Unit Tests
-        run: vendor/bin/phpunit tests/Unit --no-coverage
+      - name: Run PHPUnit outside the dedicated RLS group
+        run: vendor/bin/phpunit --configuration phpunit.xml.dist --exclude-group rls --no-coverage
 
-      - name: Wait for PostgreSQL
-        run: |
-          until pg_isready -h localhost -p 5432 -U test_user; do
-            echo "Waiting for PostgreSQL..."
-            sleep 2
-          done
-
-      - name: Setup PostgreSQL test database
-        run: |
-          PGPASSWORD=test_password psql -h localhost -U test_user -d multi_tenant_test -f tests/sql/init.sql
-
-      - name: Run RLS Isolation Tests
-        run: vendor/bin/phpunit tests/Integration/RlsIsolationTest.php --no-coverage
-        env:
-          DATABASE_URL: postgresql://test_user:test_password@localhost:5432/multi_tenant_test
-
-      - name: Run Resolver Chain Tests
-        run: vendor/bin/phpunit tests/Integration/ResolverChainHttpTest.php tests/Integration/ResolverChainTest.php --no-coverage
-        env:
-          DATABASE_URL: postgresql://test_user:test_password@localhost:5432/multi_tenant_test
-
-      - name: Run Messenger Tests
-        run: vendor/bin/phpunit tests/Integration/MessengerTenantPropagationTest.php --no-coverage
-        env:
-          DATABASE_URL: postgresql://test_user:test_password@localhost:5432/multi_tenant_test
-
-      - name: Run CLI Tests
-        run: vendor/bin/phpunit tests/Integration/CliTenantContextTest.php --no-coverage
-        env:
-          DATABASE_URL: postgresql://test_user:test_password@localhost:5432/multi_tenant_test
-
-      - name: Run Decorators Tests
-        run: vendor/bin/phpunit tests/Integration/DecoratorsTest.php --no-coverage
-        env:
-          DATABASE_URL: postgresql://test_user:test_password@localhost:5432/multi_tenant_test
-
-      - name: Run All Integration Tests
-        run: vendor/bin/phpunit tests/Integration --no-coverage
-        env:
-          DATABASE_URL: postgresql://test_user:test_password@localhost:5432/multi_tenant_test
+      - name: Run PostgreSQL RLS tests
+        run: vendor/bin/phpunit --configuration phpunit.xml.dist --group rls --no-coverage

--- a/.github/workflows/test-kit.yml
+++ b/.github/workflows/test-kit.yml
@@ -135,6 +135,12 @@ jobs:
           fi
           composer update "${options[@]}"
 
+      - name: Update static analysis tooling for the lowest runtime
+        if: matrix.dependencies == "lowest"
+        run: >-
+          composer update --prefer-dist --no-progress --no-interaction
+          phpstan/phpstan phpstan/phpstan-doctrine phpstan/phpstan-symfony
+
       - name: Validate Composer metadata
         run: composer validate --strict
 

--- a/.github/workflows/test-kit.yml
+++ b/.github/workflows/test-kit.yml
@@ -136,7 +136,7 @@ jobs:
           composer update "${options[@]}"
 
       - name: Update static analysis tooling for the lowest runtime
-        if: matrix.dependencies == "lowest"
+        if: matrix.dependencies == 'lowest'
         run: >-
           composer update --prefer-dist --no-progress --no-interaction
           phpstan/phpstan phpstan/phpstan-doctrine phpstan/phpstan-symfony

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Persisted the PostgreSQL tenant setting for the database session and clear stale tenant state when no context is active.
 
 ### Added
+- Added a required PHP 8.3–8.5, Symfony 7.4/8.0, Doctrine ORM 3.5/3.6, and DBAL 3.8/4.4 compatibility matrix.
+- Documented the supported combinations and compatibility removal policy.
 - **Symfony 8.0 & 7.4 Compatibility**
   - Updated `composer.json` to support Symfony `^7.4` and `^8.0` components
   - Updated `symfony/contracts` to support `^3.4` and `^4.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0-RC3] - 2026-04-05
 
 ### Fixed
+- Declared the PSR Simple Cache 3 requirement used by the optional typed PSR-16 decorator and updated Console tests for Symfony 8.
 - Replaced the false-positive RLS target with six effective PostgreSQL 16 tests using a non-superuser application role and raw DBAL queries.
 - Persisted the PostgreSQL tenant setting for the database session and clear stale tenant state when no context is active.
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test-kit: ## Run Test Kit integration tests
 	$(DOCKER_RUN) vendor/bin/phpunit tests/Integration --no-coverage
 
 test-rls: ## Run RLS isolation tests (requires PostgreSQL)
-	docker compose -f tests/docker-compose.yml run --rm php-rls vendor/bin/phpunit tests/Integration/RlsIsolationTest.php --no-coverage
+	docker compose -f tests/docker-compose.yml run --rm php-rls vendor/bin/phpunit --group rls --no-coverage
 
 test-resolvers: ## Run resolver chain tests
 	$(DOCKER_RUN) vendor/bin/phpunit tests/Integration/ResolverChainHttpTest.php tests/Integration/ResolverChainTest.php --no-coverage
@@ -102,7 +102,7 @@ test-with-postgres: ## Run RLS tests with PostgreSQL
 	@set -e; \
 	trap 'docker compose -f tests/docker-compose.yml down' EXIT; \
 	docker compose -f tests/docker-compose.yml up -d --wait postgres; \
-	docker compose -f tests/docker-compose.yml run --rm php-rls vendor/bin/phpunit tests/Integration/RlsIsolationTest.php --no-coverage
+	docker compose -f tests/docker-compose.yml run --rm php-rls vendor/bin/phpunit --group rls --no-coverage
 
 validate-testkit: ## Validate Test Kit setup and configuration
 	docker compose -f tests/docker-compose.yml run --rm --no-deps php-rls php tests/validate-testkit.php

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ class DashboardController extends AbstractController
 
 ### 🚀 Getting Started
 - [Installation & Setup](docs/installation.md) - Complete installation guide
+- [Compatibility Policy](docs/compatibility.md) - Tested PHP, Symfony, and Doctrine combinations
 - [Configuration Reference](docs/configuration.md) - All configuration options
 - [Database Strategies](docs/database-strategies.md) - Shared DB vs Multi-DB
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "phpstan/phpstan-symfony": "^2.0",
     "phpunit/php-code-coverage": "^12.3.1",
     "phpunit/phpunit": "^12.2.5",
-    "psr/simple-cache": "*",
+    "psr/simple-cache": "^3.0",
     "roave/security-advisories": "dev-latest",
     "symfony/mailer": "^7.4 || ^8.0",
     "symfony/messenger": "^7.4 || ^8.0",
@@ -66,6 +66,9 @@
   },
   "scripts": {
     "php-cs-fixer": "php-cs-fixer fix src --verbose --rules=@Symfony"
+  },
+  "conflict": {
+    "psr/simple-cache": "<3.0"
   },
   "suggest": {
     "psr/simple-cache": "Needed for PSR-16 simple cache tenant-aware decorators",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   ],
   "require": {
     "php": ">=8.3",
-    "doctrine/doctrine-bundle": "^2.7",
+    "doctrine/doctrine-bundle": "^2.7 || ^3.3",
     "doctrine/doctrine-migrations-bundle": "^3.0",
     "monolog/monolog": "^3",
     "symfony/cache": "^7.4 || ^8.0",

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,42 @@
+# Compatibility Policy
+
+## Supported runtime matrix
+
+Every supported combination is resolved from `composer.json` and exercised in GitHub Actions. The matrix deliberately lists valid combinations instead of taking a Cartesian product.
+
+| PHP | Symfony | Doctrine ORM | Doctrine DBAL | Dependency mode |
+|---|---|---|---|---|
+| 8.3 | 7.4 | 3.5 | 3.8 | Lowest supported versions |
+| 8.3 | 7.4 | 3.6 | 4.4 | Latest supported versions |
+| 8.4 | 7.4 | 3.6 | 4.4 | Latest supported versions |
+| 8.4 | 8.0 | 3.6 | 4.4 | Latest supported versions |
+| 8.5 | 7.4 | 3.6 | 4.4 | Latest supported versions |
+| 8.5 | 8.0 | 3.6 | 4.4 | Latest supported versions |
+
+Symfony 8 is not tested on PHP 8.3 because Symfony 8 requires PHP 8.4 or later. Doctrine DBAL 3 support is exercised with the oldest supported ORM line, while DBAL 4 is exercised with the current ORM line.
+
+Each matrix cell runs strict Composer validation, a dependency security audit, PHPStan at maximum level, the PHPUnit suite, and the PostgreSQL 16 RLS group. Coding style is a separate required job on PHP 8.3.
+
+## Version policy
+
+- PHP versions are supported while they receive upstream security fixes and remain compatible with a supported Symfony branch.
+- Symfony 7.4 and 8.0 are the supported framework branches.
+- Doctrine ORM 3.5 and later within the 3.x line are supported.
+- Doctrine DBAL 3.8 and the 4.x line are supported through explicitly tested combinations.
+- PostgreSQL 16 is the reference database for RLS guarantees.
+
+Removing a matrix entry is a compatibility change. It requires evidence that the combination is no longer resolvable or supportable, an updated changelog, and migration guidance where applicable.
+
+## Local validation
+
+The default local environment validates the latest PHP 8.3-compatible dependency set:
+
+```bash
+make composer-validate
+make phpstan
+make csfixer-check
+make test
+make test-with-postgres
+```
+
+The GitHub Actions matrix is authoritative for cross-version support because the bundle intentionally does not commit a Composer lock file.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -6,7 +6,7 @@ Every supported combination is resolved from `composer.json` and exercised in Gi
 
 | PHP | Symfony | DoctrineBundle | Doctrine ORM | Doctrine DBAL | Dependency mode |
 |---|---|---|---|---|---|
-| 8.3 | 7.4 | 2.19 | 3.5 | 3.8 | Lowest supported versions |
+| 8.3 | 7.4 | 2.19 | 3.5 | 3.8 | Lowest supported runtime versions |
 | 8.3 | 7.4 | 2.19 | 3.6 | 4.4 | Latest supported versions |
 | 8.4 | 7.4 | 3.3 | 3.6 | 4.4 | Latest supported versions |
 | 8.4 | 8.0 | 3.3 | 3.6 | 4.4 | Latest supported versions |
@@ -14,6 +14,8 @@ Every supported combination is resolved from `composer.json` and exercised in Gi
 | 8.5 | 8.0 | 3.3 | 3.6 | 4.4 | Latest supported versions |
 
 Symfony 8 is not tested on PHP 8.3 because Symfony 8 requires PHP 8.4 or later. DoctrineBundle 2.19 preserves the PHP 8.3 path, while DoctrineBundle 3.3 provides the Symfony 8-compatible path on PHP 8.4 and later. Doctrine DBAL 3 support is exercised with the oldest supported ORM line, while DBAL 4 is exercised with the current ORM line.
+
+The lowest cell resolves runtime packages with `--prefer-lowest`, then updates PHPStan and its extensions so current static-analysis rules evaluate that runtime graph.
 
 Each matrix cell runs strict Composer validation, a dependency security audit, PHPStan at maximum level, the PHPUnit suite, and the PostgreSQL 16 RLS group. Security advisories fail the audit. Abandoned transitive packages are reported because the lowest-supported dependency graph can contain upstream packages that Composer marks as abandoned. Coding style is a separate required job on PHP 8.3.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -4,18 +4,18 @@
 
 Every supported combination is resolved from `composer.json` and exercised in GitHub Actions. The matrix deliberately lists valid combinations instead of taking a Cartesian product.
 
-| PHP | Symfony | Doctrine ORM | Doctrine DBAL | Dependency mode |
-|---|---|---|---|---|
-| 8.3 | 7.4 | 3.5 | 3.8 | Lowest supported versions |
-| 8.3 | 7.4 | 3.6 | 4.4 | Latest supported versions |
-| 8.4 | 7.4 | 3.6 | 4.4 | Latest supported versions |
-| 8.4 | 8.0 | 3.6 | 4.4 | Latest supported versions |
-| 8.5 | 7.4 | 3.6 | 4.4 | Latest supported versions |
-| 8.5 | 8.0 | 3.6 | 4.4 | Latest supported versions |
+| PHP | Symfony | DoctrineBundle | Doctrine ORM | Doctrine DBAL | Dependency mode |
+|---|---|---|---|---|---|
+| 8.3 | 7.4 | 2.19 | 3.5 | 3.8 | Lowest supported versions |
+| 8.3 | 7.4 | 2.19 | 3.6 | 4.4 | Latest supported versions |
+| 8.4 | 7.4 | 3.3 | 3.6 | 4.4 | Latest supported versions |
+| 8.4 | 8.0 | 3.3 | 3.6 | 4.4 | Latest supported versions |
+| 8.5 | 7.4 | 3.3 | 3.6 | 4.4 | Latest supported versions |
+| 8.5 | 8.0 | 3.3 | 3.6 | 4.4 | Latest supported versions |
 
-Symfony 8 is not tested on PHP 8.3 because Symfony 8 requires PHP 8.4 or later. Doctrine DBAL 3 support is exercised with the oldest supported ORM line, while DBAL 4 is exercised with the current ORM line.
+Symfony 8 is not tested on PHP 8.3 because Symfony 8 requires PHP 8.4 or later. DoctrineBundle 2.19 preserves the PHP 8.3 path, while DoctrineBundle 3.3 provides the Symfony 8-compatible path on PHP 8.4 and later. Doctrine DBAL 3 support is exercised with the oldest supported ORM line, while DBAL 4 is exercised with the current ORM line.
 
-Each matrix cell runs strict Composer validation, a dependency security audit, PHPStan at maximum level, the PHPUnit suite, and the PostgreSQL 16 RLS group. Coding style is a separate required job on PHP 8.3.
+Each matrix cell runs strict Composer validation, a dependency security audit, PHPStan at maximum level, the PHPUnit suite, and the PostgreSQL 16 RLS group. Security advisories fail the audit. Abandoned transitive packages are reported because the lowest-supported dependency graph can contain upstream packages that Composer marks as abandoned. Coding style is a separate required job on PHP 8.3.
 
 ## Version policy
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -24,6 +24,7 @@ Each matrix cell runs strict Composer validation, a dependency security audit, P
 - Doctrine ORM 3.5 and later within the 3.x line are supported.
 - Doctrine DBAL 3.8 and the 4.x line are supported through explicitly tested combinations.
 - PostgreSQL 16 is the reference database for RLS guarantees.
+- The optional PSR-16 decorator requires `psr/simple-cache` 3.x because earlier interface versions do not define the typed PSR-16 signatures implemented by the bundle.
 
 Removing a matrix entry is a compatibility change. It requires evidence that the combination is no longer resolvable or supportable, an updated changelog, and migration guidance where applicable.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,6 +83,7 @@ The Zhortein Multi-Tenant Bundle provides a comprehensive, production-ready solu
 
 - **PHP**: >= 8.3
 - **Symfony**: >= 7.4 | 8.0
+- **Tested matrix**: See the [compatibility policy](compatibility.md)
 - **Database**: PostgreSQL 16 (via Doctrine ORM)
 - **Extensions**: `ext-json`, `ext-pdo`
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -15,6 +15,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 final class Configuration implements ConfigurationInterface
 {
+    /**
+     * @return TreeBuilder<'array'>
+     */
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('zhortein_multi_tenant');

--- a/tests/Functional/Database/RlsIntegrationTest.php
+++ b/tests/Functional/Database/RlsIntegrationTest.php
@@ -7,7 +7,7 @@ namespace Zhortein\MultiTenantBundle\Tests\Functional\Database;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Zhortein\MultiTenantBundle\Context\TenantContext;
 use Zhortein\MultiTenantBundle\Database\TenantSessionConfigurator;
@@ -15,320 +15,200 @@ use Zhortein\MultiTenantBundle\Registry\InMemoryTenantRegistry;
 use Zhortein\MultiTenantBundle\Tests\Fixtures\Entity\TestTenant;
 
 /**
- * Functional tests for PostgreSQL Row-Level Security (RLS) integration.
- *
- * These tests verify that RLS policies work correctly even when Doctrine
- * tenant filters are disabled, providing defense-in-depth protection.
- *
- * Note: These tests require a PostgreSQL database connection to be meaningful.
- * They will be skipped if PostgreSQL is not available.
+ * Functional PostgreSQL RLS tests executed through a non-superuser role.
  *
  * @group functional
  * @group database
  * @group rls
  */
+#[Group('rls')]
 final class RlsIntegrationTest extends TestCase
 {
-    private ?Connection $connection = null;
+    private Connection $adminConnection;
+    private Connection $connection;
     private TenantContext $tenantContext;
-    private InMemoryTenantRegistry $tenantRegistry;
-    private TenantSessionConfigurator $sessionConfigurator;
+    private TenantSessionConfigurator $configurator;
+    private TestTenant $tenantA;
+    private TestTenant $tenantB;
 
     protected function setUp(): void
     {
-        // Try to create a PostgreSQL connection for testing
-        // This will be skipped if no PostgreSQL is available
         try {
-            $this->connection = $this->createPostgreSQLConnection();
-            // Test the connection
-            $this->connection->executeQuery('SELECT 1');
-        } catch (\Exception $e) {
-            $this->markTestSkipped('PostgreSQL connection not available for RLS testing: '.$e->getMessage());
+            $this->adminConnection = DriverManager::getConnection($this->parameters(
+                $_ENV['TEST_DATABASE_USER'] ?? 'test_user',
+                $_ENV['TEST_DATABASE_PASSWORD'] ?? 'test_password',
+            ));
+            $this->adminConnection->executeQuery('SELECT 1')->fetchOne();
+            $this->setUpDatabase();
+            $this->connection = DriverManager::getConnection($this->parameters(
+                $_ENV['TEST_DATABASE_APP_USER'] ?? 'rls_test_app',
+                $_ENV['TEST_DATABASE_APP_PASSWORD'] ?? 'rls_test_password',
+            ));
+            $this->connection->executeQuery('SELECT 1')->fetchOne();
+        } catch (\Throwable $exception) {
+            if ('1' === ($_ENV['TEST_DATABASE_REQUIRED'] ?? null)) {
+                throw new \RuntimeException('The required PostgreSQL RLS environment is unavailable.', 0, $exception);
+            }
+
+            $this->markTestSkipped('PostgreSQL is not available; run `make test-with-postgres` for mandatory RLS coverage.');
         }
 
+        $this->tenantA = $this->tenant(1, 'tenant-a');
+        $this->tenantB = $this->tenant(2, 'tenant-b');
+        $registry = new InMemoryTenantRegistry();
+        $registry->addTenant($this->tenantA);
+        $registry->addTenant($this->tenantB);
         $this->tenantContext = new TenantContext();
-        $this->tenantRegistry = new InMemoryTenantRegistry();
-        $this->sessionConfigurator = new TenantSessionConfigurator(
+        $this->configurator = new TenantSessionConfigurator(
             $this->tenantContext,
             $this->connection,
-            $this->tenantRegistry,
-            true, // RLS enabled
-            'app.tenant_id'
+            $registry,
+            true,
         );
-
-        $this->setupTestData();
     }
 
     protected function tearDown(): void
     {
-        if (null !== $this->connection) {
-            $this->cleanupTestData();
+        if (isset($this->connection) && $this->connection->isConnected()) {
+            $this->connection->close();
         }
+        if (isset($this->adminConnection) && $this->adminConnection->isConnected()) {
+            $this->adminConnection->executeStatement('DROP TABLE IF EXISTS functional_rls_products');
+            $this->adminConnection->executeStatement('DROP TABLE IF EXISTS functional_rls_tenants');
+            $this->adminConnection->close();
+        }
+
         parent::tearDown();
     }
 
-    public function testRlsPreventsAccessToOtherTenantsDataWhenFiltersDisabled(): void
+    public function testRlsPreventsCrossTenantReadsThroughRawDbal(): void
     {
-        // Create two tenants
-        $tenant1 = $this->createTestTenant(1, 'tenant1', 'Tenant 1');
-        $tenant2 = $this->createTestTenant(2, 'tenant2', 'Tenant 2');
+        $this->useTenant($this->tenantA);
+        self::assertSame(['Tenant A product'], $this->names());
 
-        // Add tenants to registry
-        $this->tenantRegistry->addTenant($tenant1);
-        $this->tenantRegistry->addTenant($tenant2);
-
-        // Insert test data directly via DBAL
-        $this->connection->insert('test_tenants', [
-            'id' => 1,
-            'slug' => 'tenant1',
-            'name' => 'Tenant 1',
-            'active' => true,
-        ]);
-        $this->connection->insert('test_tenants', [
-            'id' => 2,
-            'slug' => 'tenant2',
-            'name' => 'Tenant 2',
-            'active' => true,
-        ]);
-
-        $this->connection->insert('test_products', [
-            'tenant_id' => 1,
-            'name' => 'Product 1',
-            'price' => '10.00',
-        ]);
-        $this->connection->insert('test_products', [
-            'tenant_id' => 2,
-            'name' => 'Product 2',
-            'price' => '20.00',
-        ]);
-
-        // Set up RLS policies for the test_products table
-        $this->setupRlsPolicies();
-
-        // Set tenant context to tenant1
-        $this->tenantContext->setTenant($tenant1);
-        $this->configureSessionForCurrentTenant();
-
-        // Disable Doctrine tenant filter to test RLS isolation
-        $filters = $this->entityManager->getFilters();
-        if ($filters->has('tenant_filter')) {
-            $filters->disable('tenant_filter');
-        }
-
-        // Try to query all products directly via DBAL (bypassing Doctrine ORM filters)
-        $products = $this->connection->fetchAllAssociative('SELECT * FROM test_products ORDER BY id');
-
-        // With RLS enabled, should only see tenant1's product even with filters disabled
-        $this->assertCount(1, $products, 'RLS should prevent access to other tenants\' data');
-        $this->assertSame('Product 1', $products[0]['name']);
-        $this->assertSame($tenant1->getId(), (int) $products[0]['tenant_id']);
-
-        // Switch to tenant2
-        $this->tenantContext->setTenant($tenant2);
-        $this->configureSessionForCurrentTenant();
-
-        // Query again - should now see only tenant2's product
-        $products = $this->connection->fetchAllAssociative('SELECT * FROM test_products ORDER BY id');
-
-        $this->assertCount(1, $products, 'RLS should show only current tenant\'s data');
-        $this->assertSame('Product 2', $products[0]['name']);
-        $this->assertSame($tenant2->getId(), (int) $products[0]['tenant_id']);
+        $this->useTenant($this->tenantB);
+        self::assertSame(['Tenant B product'], $this->names());
     }
 
-    public function testRlsPreventsInsertWithWrongTenantId(): void
+    public function testRlsPreventsInsertWithAnotherTenantIdentifier(): void
     {
-        $tenant1 = $this->createTestTenant(1, 'tenant1', 'Tenant 1');
-        $tenant2 = $this->createTestTenant(2, 'tenant2', 'Tenant 2');
+        $this->useTenant($this->tenantA);
 
-        // Insert tenants
-        $this->connection->insert('test_tenants', [
-            'id' => 1,
-            'slug' => 'tenant1',
-            'name' => 'Tenant 1',
-            'active' => true,
-        ]);
-        $this->connection->insert('test_tenants', [
-            'id' => 2,
-            'slug' => 'tenant2',
-            'name' => 'Tenant 2',
-            'active' => true,
-        ]);
-
-        $this->setupRlsPolicies();
-
-        // Set tenant context to tenant1
-        $this->tenantContext->setTenant($tenant1);
-        $this->configureSessionForCurrentTenant();
-
-        // Try to insert a product with tenant2's ID while tenant1 is active
-        // This should fail due to RLS policy
-        $this->expectException(Exception::class);
-
-        $this->connection->insert('test_products', [
-            'tenant_id' => $tenant2->getId(),
-            'name' => 'Malicious Product',
-            'price' => '99.99',
-        ]);
-    }
-
-    public function testRlsAllowsInsertWithCorrectTenantId(): void
-    {
-        $tenant1 = $this->createTestTenant(1, 'tenant1', 'Tenant 1');
-
-        // Insert tenant
-        $this->connection->insert('test_tenants', [
-            'id' => 1,
-            'slug' => 'tenant1',
-            'name' => 'Tenant 1',
-            'active' => true,
-        ]);
-
-        $this->setupRlsPolicies();
-
-        // Set tenant context to tenant1
-        $this->tenantContext->setTenant($tenant1);
-        $this->configureSessionForCurrentTenant();
-
-        // Insert a product with the correct tenant ID - should succeed
-        $this->connection->insert('test_products', [
-            'tenant_id' => $tenant1->getId(),
-            'name' => 'Valid Product',
-            'price' => '15.99',
-        ]);
-
-        // Verify the product was inserted
-        $products = $this->connection->fetchAllAssociative('SELECT * FROM test_products WHERE name = ?', ['Valid Product']);
-        $this->assertCount(1, $products);
-        $this->assertSame($tenant1->getId(), (int) $products[0]['tenant_id']);
-    }
-
-    public function testRlsWorksWithoutTenantContext(): void
-    {
-        $tenant1 = $this->createTestTenant(1, 'tenant1', 'Tenant 1');
-
-        // Insert tenant and product
-        $this->connection->insert('test_tenants', [
-            'id' => 1,
-            'slug' => 'tenant1',
-            'name' => 'Tenant 1',
-            'active' => true,
-        ]);
-        $this->connection->insert('test_products', [
-            'tenant_id' => 1,
-            'name' => 'Product 1',
-            'price' => '10.00',
-        ]);
-
-        $this->setupRlsPolicies();
-
-        // Clear tenant context (no session variable set)
-        $this->tenantContext->clear();
-        $this->connection->executeStatement('SELECT set_config(?, ?, false)', ['app.tenant_id', '']);
-
-        // Query should return no results due to RLS policy
-        $products = $this->connection->fetchAllAssociative('SELECT * FROM test_products');
-        $this->assertCount(0, $products, 'RLS should block access when no tenant context is set');
-    }
-
-    private function isPostgreSQL(): bool
-    {
-        return $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform;
-    }
-
-    private function setupTestData(): void
-    {
-        // Create test tables if they don't exist
-        $this->connection->executeStatement('
-            CREATE TABLE IF NOT EXISTS test_tenants (
-                id SERIAL PRIMARY KEY,
-                slug VARCHAR(255) NOT NULL UNIQUE,
-                name VARCHAR(255) NOT NULL,
-                active BOOLEAN NOT NULL DEFAULT TRUE,
-                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-            )
-        ');
-
-        $this->connection->executeStatement('
-            CREATE TABLE IF NOT EXISTS test_products (
-                id SERIAL PRIMARY KEY,
-                tenant_id INTEGER NOT NULL,
-                name VARCHAR(255) NOT NULL,
-                price DECIMAL(10,2) NOT NULL,
-                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                FOREIGN KEY (tenant_id) REFERENCES test_tenants (id)
-            )
-        ');
-    }
-
-    private function cleanupTestData(): void
-    {
         try {
-            // Drop RLS policies
-            $this->connection->executeStatement('DROP POLICY IF EXISTS tenant_isolation_test_products ON test_products');
-            $this->connection->executeStatement('ALTER TABLE test_products DISABLE ROW LEVEL SECURITY');
-
-            // Clean up test data
-            $this->connection->executeStatement('DELETE FROM test_products');
-            $this->connection->executeStatement('DELETE FROM test_tenants');
-        } catch (Exception) {
-            // Ignore cleanup errors
+            $this->connection->insert('functional_rls_products', [
+                'tenant_id' => 2,
+                'name' => 'Cross-tenant insert',
+            ]);
+            self::fail('RLS must reject an insert for another tenant.');
+        } catch (Exception $exception) {
+            self::assertStringContainsString('row-level security policy', $exception->getMessage());
         }
     }
 
-    private function setupRlsPolicies(): void
+    public function testRlsAllowsInsertForTheCurrentTenant(): void
     {
-        // Enable RLS on test_products table
-        $this->connection->executeStatement('ALTER TABLE test_products ENABLE ROW LEVEL SECURITY');
+        $this->useTenant($this->tenantA);
+        $this->connection->insert('functional_rls_products', [
+            'tenant_id' => 1,
+            'name' => 'Tenant A second product',
+        ]);
 
-        // Drop existing policy if it exists
-        $this->connection->executeStatement('DROP POLICY IF EXISTS tenant_isolation_test_products ON test_products');
-
-        // Create RLS policy
-        $this->connection->executeStatement('
-            CREATE POLICY tenant_isolation_test_products ON test_products
-            USING (tenant_id::text = current_setting(\'app.tenant_id\', true))
-        ');
+        self::assertSame(['Tenant A product', 'Tenant A second product'], $this->names());
     }
 
-    private function configureSessionForCurrentTenant(): void
+    public function testRlsFailsClosedWithoutTenantContext(): void
     {
-        $tenant = $this->tenantContext->getTenant();
-        if (null !== $tenant) {
-            $this->connection->executeStatement(
-                'SELECT set_config(?, ?, false)',
-                ['app.tenant_id', (string) $tenant->getId()]
-            );
-        }
+        $this->useTenant($this->tenantA);
+        self::assertNotEmpty($this->names());
+
+        $this->tenantContext->clear();
+        $this->configurator->setConfig();
+
+        self::assertSame([], $this->names());
     }
 
-    private function createPostgreSQLConnection(): Connection
+    private function setUpDatabase(): void
     {
-        // Try to connect to a test PostgreSQL database
-        // This can be configured via environment variables
-        $connectionParams = [
+        $this->adminConnection->executeStatement(<<<'SQL'
+            DO $$
+            BEGIN
+                IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'rls_test_app') THEN
+                    CREATE ROLE rls_test_app LOGIN PASSWORD 'rls_test_password' NOSUPERUSER NOCREATEDB NOCREATEROLE;
+                END IF;
+            END
+            $$
+            SQL);
+        $this->adminConnection->executeStatement('DROP TABLE IF EXISTS functional_rls_products');
+        $this->adminConnection->executeStatement('DROP TABLE IF EXISTS functional_rls_tenants');
+        $this->adminConnection->executeStatement(<<<'SQL'
+            CREATE TABLE functional_rls_tenants (
+                id INTEGER PRIMARY KEY,
+                slug VARCHAR(255) NOT NULL UNIQUE
+            )
+            SQL);
+        $this->adminConnection->executeStatement(<<<'SQL'
+            CREATE TABLE functional_rls_products (
+                id SERIAL PRIMARY KEY,
+                tenant_id INTEGER NOT NULL REFERENCES functional_rls_tenants(id),
+                name VARCHAR(255) NOT NULL
+            )
+            SQL);
+        $this->adminConnection->executeStatement(<<<'SQL'
+            INSERT INTO functional_rls_tenants (id, slug)
+            VALUES (1, 'tenant-a'), (2, 'tenant-b')
+            SQL);
+        $this->adminConnection->executeStatement(<<<'SQL'
+            INSERT INTO functional_rls_products (tenant_id, name)
+            VALUES (1, 'Tenant A product'), (2, 'Tenant B product')
+            SQL);
+        $this->adminConnection->executeStatement('ALTER TABLE functional_rls_products ENABLE ROW LEVEL SECURITY');
+        $this->adminConnection->executeStatement('ALTER TABLE functional_rls_products FORCE ROW LEVEL SECURITY');
+        $this->adminConnection->executeStatement(<<<'SQL'
+            CREATE POLICY functional_tenant_isolation ON functional_rls_products
+            FOR ALL
+            USING (tenant_id = NULLIF(current_setting('app.tenant_id', true), '')::integer)
+            WITH CHECK (tenant_id = NULLIF(current_setting('app.tenant_id', true), '')::integer)
+            SQL);
+        $this->adminConnection->executeStatement('GRANT USAGE ON SCHEMA public TO rls_test_app');
+        $this->adminConnection->executeStatement('GRANT SELECT ON functional_rls_tenants TO rls_test_app');
+        $this->adminConnection->executeStatement('GRANT SELECT, INSERT, UPDATE, DELETE ON functional_rls_products TO rls_test_app');
+        $this->adminConnection->executeStatement('GRANT USAGE, SELECT ON SEQUENCE functional_rls_products_id_seq TO rls_test_app');
+    }
+
+    private function useTenant(TestTenant $tenant): void
+    {
+        $this->tenantContext->setTenant($tenant);
+        $this->configurator->setConfig();
+    }
+
+    /** @return list<string> */
+    private function names(): array
+    {
+        return array_values(array_map(
+            static fn (array $row): string => (string) $row['name'],
+            $this->connection->fetchAllAssociative('SELECT name FROM functional_rls_products ORDER BY id'),
+        ));
+    }
+
+    /** @return array{driver: string, host: string, port: int, dbname: string, user: string, password: string} */
+    private function parameters(string $user, string $password): array
+    {
+        return [
             'driver' => 'pdo_pgsql',
-            'host' => $_ENV['TEST_DATABASE_HOST'] ?? 'localhost',
-            'port' => $_ENV['TEST_DATABASE_PORT'] ?? 5432,
-            'dbname' => $_ENV['TEST_DATABASE_NAME'] ?? 'test_multitenant',
-            'user' => $_ENV['TEST_DATABASE_USER'] ?? 'postgres',
-            'password' => $_ENV['TEST_DATABASE_PASSWORD'] ?? 'postgres',
+            'host' => $_ENV['TEST_DATABASE_HOST'] ?? '127.0.0.1',
+            'port' => (int) ($_ENV['TEST_DATABASE_PORT'] ?? 5432),
+            'dbname' => $_ENV['TEST_DATABASE_NAME'] ?? 'multi_tenant_test',
+            'user' => $user,
+            'password' => $password,
         ];
-
-        // @phpstan-ignore-next-line
-        return DriverManager::getConnection($connectionParams);
     }
 
-    private function createTestTenant(int $id, string $slug, string $name): TestTenant
+    private function tenant(int $id, string $slug): TestTenant
     {
         $tenant = new TestTenant();
-        // Use reflection to set the ID since it's normally auto-generated
-        $reflection = new \ReflectionClass($tenant);
-        $idProperty = $reflection->getProperty('id');
-        $idProperty->setAccessible(true);
-        $idProperty->setValue($tenant, $id);
-
+        (new \ReflectionProperty($tenant, 'id'))->setValue($tenant, $id);
         $tenant->setSlug($slug);
-        $tenant->setName($name);
+        $tenant->setName(ucwords(str_replace('-', ' ', $slug)));
         $tenant->setActive(true);
 
         return $tenant;

--- a/tests/Integration/Command/SyncRlsPoliciesCommandIntegrationTest.php
+++ b/tests/Integration/Command/SyncRlsPoliciesCommandIntegrationTest.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Zhortein\MultiTenantBundle\Command\SyncRlsPoliciesCommand;
 
@@ -64,8 +63,6 @@ final class SyncRlsPoliciesCommandIntegrationTest extends TestCase
             'tenant_isolation'
         );
 
-        $application = new Application();
-        $application->addCommand($command);
         $commandTester = new CommandTester($command);
 
         $exitCode = $commandTester->execute([]);

--- a/tests/Integration/Command/SyncRlsPoliciesCommandIntegrationTest.php
+++ b/tests/Integration/Command/SyncRlsPoliciesCommandIntegrationTest.php
@@ -65,7 +65,7 @@ final class SyncRlsPoliciesCommandIntegrationTest extends TestCase
         );
 
         $application = new Application();
-        $application->add($command);
+        $application->addCommand($command);
         $commandTester = new CommandTester($command);
 
         $exitCode = $commandTester->execute([]);

--- a/tests/Integration/Command/TenantCommandsIntegrationTest.php
+++ b/tests/Integration/Command/TenantCommandsIntegrationTest.php
@@ -40,13 +40,13 @@ final class TenantCommandsIntegrationTest extends TestCase
         $this->tenantRegistry->addTenant($tenant2);
 
         $this->application = new Application();
-        $this->application->addCommand(new ListTenantsCommand(
+        $this->registerCommand(new ListTenantsCommand(
             $this->tenantRegistry,
             $this->tenantContext,
             $this->createMock(\Doctrine\ORM\EntityManagerInterface::class),
             'App\\Entity\\Tenant'
         ));
-        $this->application->addCommand(new TenantImpersonateCommand(
+        $this->registerCommand(new TenantImpersonateCommand(
             $this->tenantRegistry,
             $this->tenantContext,
             true
@@ -252,6 +252,17 @@ final class TenantCommandsIntegrationTest extends TestCase
         $this->assertSame(Command::SUCCESS, $commandTester2->getStatusCode());
         $this->assertStringContainsString('tenant2', $commandTester2->getDisplay());
         $this->assertStringNotContainsString('tenant1', $commandTester2->getDisplay());
+    }
+
+    private function registerCommand(Command $command): void
+    {
+        if (method_exists($this->application, 'addCommand')) {
+            $this->application->addCommand($command);
+
+            return;
+        }
+
+        $this->application->add($command);
     }
 
     private function createMockTenant(string $id, string $slug, string $name): TenantInterface

--- a/tests/Integration/Command/TenantCommandsIntegrationTest.php
+++ b/tests/Integration/Command/TenantCommandsIntegrationTest.php
@@ -40,13 +40,13 @@ final class TenantCommandsIntegrationTest extends TestCase
         $this->tenantRegistry->addTenant($tenant2);
 
         $this->application = new Application();
-        $this->application->add(new ListTenantsCommand(
+        $this->application->addCommand(new ListTenantsCommand(
             $this->tenantRegistry,
             $this->tenantContext,
             $this->createMock(\Doctrine\ORM\EntityManagerInterface::class),
             'App\\Entity\\Tenant'
         ));
-        $this->application->add(new TenantImpersonateCommand(
+        $this->application->addCommand(new TenantImpersonateCommand(
             $this->tenantRegistry,
             $this->tenantContext,
             true

--- a/tests/Integration/RlsIsolationTest.php
+++ b/tests/Integration/RlsIsolationTest.php
@@ -7,6 +7,7 @@ namespace Zhortein\MultiTenantBundle\Tests\Integration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Zhortein\MultiTenantBundle\Context\TenantContext;
 use Zhortein\MultiTenantBundle\Database\TenantSessionConfigurator;
@@ -21,6 +22,7 @@ use Zhortein\MultiTenantBundle\Tests\Fixtures\Entity\TestTenant;
  * cannot bypass the policy, and raw SQL keeps the proof independent from the
  * Doctrine tenant filter.
  */
+#[Group('rls')]
 final class RlsIsolationTest extends TestCase
 {
     private const int TENANT_A_ID = 1;

--- a/tests/Unit/Command/SyncRlsPoliciesCommandTest.php
+++ b/tests/Unit/Command/SyncRlsPoliciesCommandTest.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use Zhortein\MultiTenantBundle\Attribute\AsTenantAware;
@@ -48,8 +47,6 @@ final class SyncRlsPoliciesCommandTest extends TestCase
             'tenant_isolation'
         );
 
-        $application = new Application();
-        $application->addCommand($this->command);
         $this->commandTester = new CommandTester($this->command);
     }
 

--- a/tests/Unit/Command/SyncRlsPoliciesCommandTest.php
+++ b/tests/Unit/Command/SyncRlsPoliciesCommandTest.php
@@ -49,7 +49,7 @@ final class SyncRlsPoliciesCommandTest extends TestCase
         );
 
         $application = new Application();
-        $application->add($this->command);
+        $application->addCommand($this->command);
         $this->commandTester = new CommandTester($this->command);
     }
 

--- a/tests/Unit/Database/TenantSessionConfiguratorTest.php
+++ b/tests/Unit/Database/TenantSessionConfiguratorTest.php
@@ -187,7 +187,7 @@ final class TenantSessionConfiguratorTest extends TestCase
             ->method('getDatabasePlatform')
             ->willReturn($platform);
 
-        $exception = new class('Database error') extends \Exception implements Exception {};
+        $exception = new Exception\InvalidArgumentException('Database error');
         $this->connection
             ->method('executeStatement')
             ->willThrowException($exception);


### PR DESCRIPTION
Closes #6.

## Problem

The bundle advertised PHP 8.3+, Symfony 7.4/8.0, and DBAL 4 compatibility while GitHub Actions exercised only PHP 8.3 with one floating dependency resolution. It did not prove minimum versions, Symfony 8, PHP 8.4/8.5, DBAL 3/4 boundaries, code style, a dependency audit, the full PHPUnit suite, or effective PostgreSQL RLS coverage.

Running the full suite with pdo_pgsql also exposed four legacy functional RLS tests that had previously been skipped. They used an undefined EntityManager and the PostgreSQL superuser, so they could not establish isolation.

## Solution

- Replace the single CI job with six valid runtime combinations covering PHP 8.3-8.5, Symfony 7.4/8.0, DoctrineBundle 2.19/3.3, ORM 3.5/3.6, and DBAL 3.8/4.4.
- Run strict Composer validation, security audit, PHPStan max, PHPUnit, and PostgreSQL 16 RLS in every matrix cell.
- Keep runtime packages at their supported minimum in the lowest cell while using current PHPStan tooling.
- Add a separate Symfony-style gate.
- Group all effective RLS tests explicitly and run them separately with database availability mandatory.
- Replace the four masked functional tests with real raw-DBAL assertions through a non-superuser role.
- Publish the supported matrix, version policy, local commands, and compatibility-removal policy.

## Architecture

The matrix enumerates supported combinations rather than generating invalid Cartesian products. Symfony 8 uses DoctrineBundle 3.3 and PHP 8.4 or later; PHP 8.3 retains DoctrineBundle 2.19.

The general PHPUnit gate excludes the dedicated RLS group. The RLS gate then runs ten PostgreSQL tests through a limited application role, independently from the Doctrine tenant filter. Unavailable database infrastructure or skipped RLS coverage fails the matrix.

## Compatibility findings

The effective matrix revealed and corrected several previously masked incompatibilities:

- the root DoctrineBundle constraint excluded the stable Symfony 8-compatible 3.3 line;
- the typed optional PSR-16 decorator requires psr/simple-cache 3.x;
- Console command registration changed between early Symfony 7.4 and Symfony 8.1;
- a DBAL 4-oriented anonymous exception caused a fatal error under DBAL 3.

No announced PHP, Symfony, Doctrine, or PostgreSQL target was removed. The PSR-16 requirement is now explicit, and removing a matrix entry requires evidence and migration documentation.

## Validation

Local PHP 8.3 validation:

- strict Composer validation and dependency security audit with no advisories;
- PHPStan at maximum level with no errors;
- PHP-CS-Fixer check;
- PHPUnit: 410 tests and 1,037 assertions, with 76 existing environment-dependent skips and 263 existing notices;
- PostgreSQL 16 RLS: 10 tests and 30 assertions with no skips;
- test-kit and bundle structure validators.

GitHub Actions passed the code-style job and all six compatibility cells. Every cell ran PHPStan, PHPUnit, and the effective PostgreSQL 16 RLS group.