### PR TITLE
Minimize and classify production dependencies

### DIFF
--- a/.github/workflows/test-kit.yml
+++ b/.github/workflows/test-kit.yml
@@ -33,6 +33,31 @@ jobs:
           vendor/bin/php-cs-fixer fix src --rules=@Symfony --dry-run --diff
           vendor/bin/php-cs-fixer fix tests --rules=@Symfony --dry-run --diff
 
+  minimal-install:
+    name: Minimal production install
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          coverage: none
+
+      - name: Resolve production dependencies only
+        run: composer update --no-dev --prefer-dist --no-progress --no-interaction
+
+      - name: Validate Composer metadata
+        run: composer validate --strict
+
+      - name: Audit production dependencies
+        run: composer audit --no-interaction --abandoned=report
+
+      - name: Compile without optional integrations
+        run: php tests/minimal-install.php
+
   compatibility:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Persisted the PostgreSQL tenant setting for the database session and clear stale tenant state when no context is active.
 
 ### Added
+- Replaced Symfony ORM and test packs with direct component requirements and added a production-only minimal installation check.
+- Documented required, optional, suggested, and development-only dependencies.
 - Added a required PHP 8.3–8.5, Symfony 7.4/8.0, Doctrine ORM 3.5/3.6, and DBAL 3.8/4.4 compatibility matrix.
 - Documented the supported combinations and compatibility removal policy.
 - **Symfony 8.0 & 7.4 Compatibility**

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Install the bundle via Composer:
 composer require zhortein/multi-tenant-bundle
 ```
 
+The core dependency set and optional Mailer, Twig, Monolog, and PSR-16 integrations are listed in the [dependency classification](docs/dependencies.md).
+
 Enable the bundle in your `config/bundles.php`:
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -20,19 +20,29 @@
   ],
   "require": {
     "php": ">=8.3",
+    "doctrine/dbal": "^3.8 || ^4.4",
     "doctrine/doctrine-bundle": "^2.7 || ^3.3",
     "doctrine/doctrine-migrations-bundle": "^3.0",
-    "monolog/monolog": "^3",
-    "symfony/cache": "^7.4 || ^8.0",
+    "doctrine/migrations": "^3.0",
+    "doctrine/orm": "^3.5",
+    "doctrine/persistence": "^3.3 || ^4.0",
+    "psr/cache": "^3.0",
+    "psr/event-dispatcher": "^1.0",
+    "psr/log": "^3.0",
     "symfony/config": "^7.4 || ^8.0",
-    "symfony/contracts": "^3.4 || ^4.0",
+    "symfony/console": "^7.4 || ^8.0",
     "symfony/dependency-injection": "^7.4 || ^8.0",
+    "symfony/event-dispatcher": "^7.4 || ^8.0",
+    "symfony/event-dispatcher-contracts": "^3.4",
     "symfony/filesystem": "^7.4 || ^8.0",
+    "symfony/finder": "^7.4 || ^8.0",
+    "symfony/http-foundation": "^7.4 || ^8.0",
     "symfony/http-kernel": "^7.4 || ^8.0",
-    "symfony/orm-pack": "^2.0"
+    "symfony/messenger": "^7.4 || ^8.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^v3.75.0",
+    "monolog/monolog": "^3.0",
     "phpstan/phpstan": "^2.1",
     "phpstan/phpstan-doctrine": "^2.0",
     "phpstan/phpstan-symfony": "^2.0",
@@ -41,9 +51,9 @@
     "psr/simple-cache": "^3.0",
     "roave/security-advisories": "dev-latest",
     "symfony/mailer": "^7.4 || ^8.0",
-    "symfony/messenger": "^7.4 || ^8.0",
     "symfony/phpunit-bridge": "^7.4 || ^8.0",
-    "symfony/test-pack": "^1.1",
+    "symfony/browser-kit": "^7.4 || ^8.0",
+    "symfony/dom-crawler": "^7.4 || ^8.0",
     "symfony/twig-bundle": "^7.4 || ^8.0"
   },
   "config": {
@@ -71,9 +81,9 @@
     "psr/simple-cache": "<3.0"
   },
   "suggest": {
+    "monolog/monolog": "Needed for the optional tenant-aware Monolog processor",
     "psr/simple-cache": "Needed for PSR-16 simple cache tenant-aware decorators",
     "symfony/mailer": "Needed for dynamic tenant-aware mail sending",
-    "symfony/messenger": "Needed for dynamic tenant-aware async message dispatching",
     "symfony/twig-bundle": "Needed for templated tenant-aware emails"
   }
 }

--- a/docs/audit-2026-07.md
+++ b/docs/audit-2026-07.md
@@ -41,6 +41,8 @@ Those changes already remove `doctrine/annotations`, correct suspicious Composer
 
 PHP 8.4/8.5, Symfony 7.4/8, and supported Doctrine combinations are not confirmed. Production requirements should name the components actually used, while optional integrations should remain optional. The concrete Monolog dependency should also be reviewed in favor of PSR contracts where possible.
 
+Resolved on 2026-07-31: the compatibility matrix now verifies the announced PHP, Symfony, DoctrineBundle, ORM, and DBAL combinations. Symfony packs were replaced with direct component requirements, Monolog and Mailer are optional, and a production-only CI job compiles the container without Mailer, Twig, Monolog, or PSR-16. See [Dependency Classification](dependencies.md).
+
 The production PSR-4 mapping is coherent. The advertised test kit is under `autoload-dev` and is therefore not normally available to consuming applications.
 
 ## Demonstrated functionality

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,44 @@
+# Dependency Classification
+
+The bundle declares components directly and does not depend on Symfony packs. This keeps production installations predictable and prevents optional integrations from being installed transitively.
+
+## Required runtime components
+
+The core runtime requires:
+
+- Doctrine DBAL, ORM, Persistence, DoctrineBundle, Migrations, and DoctrineMigrationsBundle for tenant registries, filters, schema management, and tenant migration commands;
+- Symfony Config, Console, DependencyInjection, EventDispatcher, Filesystem, Finder, HttpFoundation, and HttpKernel;
+- Symfony Messenger because the public PostgreSQL RLS session configurator also provides tenant propagation middleware for workers;
+- PSR-6 cache, PSR event dispatcher, and PSR logger contracts.
+
+Local tenant-aware storage is included and requires no storage adapter package. PostgreSQL 16 remains the supported reference environment for RLS.
+
+## Optional integrations
+
+Install only the integrations used by the application:
+
+```bash
+# Tenant-aware mail delivery
+composer require symfony/mailer
+
+# Templated tenant-aware mail
+composer require symfony/mailer symfony/twig-bundle
+
+# Tenant-aware Monolog processor
+composer require monolog/monolog
+
+# PSR-16 cache decorator
+composer require psr/simple-cache:^3.0
+```
+
+Mailer services are not registered when Symfony Mailer is unavailable. Templated mail additionally requires Twig. The Monolog processor is not registered when Monolog is unavailable. PSR Simple Cache versions earlier than 3.0 are incompatible with the typed PSR-16 decorator and are explicitly rejected.
+
+Messenger is not optional in the current public API because `TenantSessionConfigurator` implements Symfony Messenger middleware. Changing that contract would require a separate backward-compatibility decision.
+
+## Development-only tools
+
+PHPUnit, PHPStan and its extensions, PHP-CS-Fixer, Symfony BrowserKit and DomCrawler, the Symfony PHPUnit Bridge, and security-advisory constraints are development dependencies. They are not installed in a production-only Composer installation.
+
+## Verification
+
+GitHub Actions resolves a production-only installation with `composer update --no-dev`, confirms that Mailer, Twig, Monolog, and PSR-16 are absent, and compiles the bundle container with those integrations unavailable. The compatibility matrix installs the development integrations and runs their existing unit, integration, and functional scenarios.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ Welcome to the comprehensive documentation for the Zhortein Multi-Tenant Bundle,
 
 ### Getting Started
 - [Installation](installation.md) - Install and enable the bundle
+- [Dependency classification](dependencies.md) - Required runtime components and optional integrations
 - [Configuration](configuration.md) - Complete configuration reference
 - [Database Strategies](database-strategies.md) - Shared DB vs Multi-DB approaches
 - [Project Overview](project-overview.md) - Architecture and implementation details

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,9 @@ This guide walks you through installing and configuring the Zhortein Multi-Tenan
 - **PHP**: >= 8.3
 - **Symfony**: >= 7.4 | 8.0
 - **PostgreSQL**: >= 16 (recommended)
-- **Doctrine ORM**: >= 3.0
+- **Doctrine ORM**: >= 3.5
+- **Doctrine DBAL**: >= 3.8 or >= 4.4
+- **Dependencies**: See the [required and optional component classification](dependencies.md)
 
 ## Installation
 

--- a/src/DependencyInjection/ZhorteinMultiTenantExtension.php
+++ b/src/DependencyInjection/ZhorteinMultiTenantExtension.php
@@ -645,7 +645,7 @@ final class ZhorteinMultiTenantExtension extends Extension
         }
 
         // Register logger processor
-        if ($config['decorators']['logger']['enabled']) {
+        if ($config['decorators']['logger']['enabled'] && interface_exists('Monolog\Processor\ProcessorInterface')) {
             $container->register('zhortein_multi_tenant.logger_processor', TenantLoggerProcessor::class)
                 ->setAutowired(true)
                 ->setArgument('$enabled', '%zhortein_multi_tenant.decorators.logger.enabled%')

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,6 +12,12 @@ The Test Kit includes:
 - **RLS Verification**: Critical tests proving PostgreSQL Row-Level Security works as defense-in-depth
 - **CI/CD Support**: Docker Compose and GitHub Actions integration
 
+## Contributor Dependency Checks
+
+The `Minimal production install` GitHub Actions job resolves Composer with `--no-dev` and runs `php tests/minimal-install.php`. The script verifies that Mailer, Twig, Monolog, and PSR-16 are absent, confirms required bundle classes remain loadable, and compiles the service container with optional integrations unavailable.
+
+Run this check in an isolated copy because `composer update --no-dev` replaces the local development vendor tree. Normal local validation continues to use the Docker-based Make targets documented below.
+
 ## 🚀 Quick Start
 
 ### 1. Basic Usage

--- a/tests/minimal-install.php
+++ b/tests/minimal-install.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Zhortein\MultiTenantBundle\Context\TenantContext;
+use Zhortein\MultiTenantBundle\DependencyInjection\ZhorteinMultiTenantExtension;
+use Zhortein\MultiTenantBundle\Storage\LocalStorage;
+use Zhortein\MultiTenantBundle\ZhorteinMultiTenantBundle;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+$optionalSymbols = [
+    "Monolog\Processor\ProcessorInterface",
+    "Psr\SimpleCache\CacheInterface",
+    "Symfony\Component\Mailer\MailerInterface",
+    "Twig\Environment",
+];
+
+foreach ($optionalSymbols as $symbol) {
+    if (class_exists($symbol) || interface_exists($symbol)) {
+        throw new RuntimeException(sprintf('Optional symbol %s must not be installed in the minimal test.', $symbol));
+    }
+}
+
+foreach ([ZhorteinMultiTenantBundle::class, TenantContext::class, LocalStorage::class] as $requiredClass) {
+    if (!class_exists($requiredClass)) {
+        throw new RuntimeException(sprintf('Required class %s is unavailable.', $requiredClass));
+    }
+}
+
+$container = new ContainerBuilder();
+$container->setParameter('kernel.environment', 'test');
+$container->setParameter('kernel.debug', false);
+$container->setParameter('kernel.project_dir', sys_get_temp_dir().'/multi-tenant-minimal-app');
+
+(new ZhorteinMultiTenantExtension())->load([[
+    'database' => ['rls' => ['enabled' => false]],
+    'decorators' => [
+        'cache' => ['enabled' => false],
+        'logger' => ['enabled' => true],
+    ],
+    'fixtures' => ['enabled' => false],
+    'mailer' => ['enabled' => true],
+    'storage' => ['enabled' => false],
+]], $container);
+
+if ($container->hasDefinition('zhortein_multi_tenant.mailer.tenant_aware')) {
+    throw new RuntimeException('Mailer services were registered without Symfony Mailer.');
+}
+
+if ($container->hasDefinition('zhortein_multi_tenant.logger_processor')) {
+    throw new RuntimeException('The Monolog processor was registered without Monolog.');
+}
+
+$container->compile();
+
+echo "Minimal production container compiled without optional integrations.\n";


### PR DESCRIPTION
Closes #7.

## Problem

The production dependency graph relied on Symfony ORM Pack and the development graph relied on Test Pack. Directly used Doctrine, Symfony, and PSR components were therefore ambiguous, while Monolog was installed for an optional processor. A production-only installation was not tested.

## Solution

- Replace ORM Pack with direct Doctrine DBAL, ORM, Persistence, migrations, DoctrineBundle, and DoctrineMigrationsBundle requirements.
- Replace the Symfony contracts metapackage with direct PSR and EventDispatcher contracts.
- Add direct Symfony component requirements for the APIs used by the bundle.
- Replace Test Pack with BrowserKit and DomCrawler development requirements.
- Move Monolog to development and suggested dependencies, and register its processor only when Monolog is available.
- Add a production-only CI job and a standalone minimal-container compilation check.
- Document required, optional, suggested, and development-only dependencies.

## Architecture

Doctrine, migrations, local storage, PSR observability contracts, and Messenger remain required. Messenger remains required because the public TenantSessionConfigurator implements Messenger middleware for RLS propagation; changing that contract is outside this backward-compatible dependency cleanup.

Mailer, Twig, Monolog, and PSR-16 are optional. The extension already avoided Mailer registration when Mailer was unavailable; it now applies the same rule to the Monolog processor. The minimal check enables those configuration paths while the packages are absent and proves that no unavailable service is registered.

## Compatibility and migration impact

No announced PHP, Symfony, Doctrine, or PostgreSQL version is removed. Applications that used ORM Pack transitive packages directly should add those packages to their own composer.json. Applications using the Monolog processor must require monolog/monolog explicitly. PSR Simple Cache 3 remains required only when the optional PSR-16 decorator is used.

## Validation

- Composer strict validation;
- Composer security audit with no advisories;
- isolated PHP 8.3 production-only resolution: 48 installed packages, with Mailer, Twig, Monolog, and PSR-16 absent;
- minimal service container compilation without optional integrations;
- PHPStan at maximum level: no errors;
- PHP-CS-Fixer check: clean;
- PHPUnit: 410 tests and 1,037 assertions;
- PostgreSQL 16 RLS: 10 tests and 30 assertions, no skips;
- test-kit and bundle structure validators.

GitHub Actions will additionally execute the full six-cell compatibility matrix and the new production-only installation job.