### PR TITLE
Validate installation in a minimal consumer application

### DIFF
--- a/.github/workflows/test-kit.yml
+++ b/.github/workflows/test-kit.yml
@@ -29,9 +29,7 @@ jobs:
           dependency-versions: highest
 
       - name: Check coding style
-        run: |
-          vendor/bin/php-cs-fixer fix src --rules=@Symfony --dry-run --diff
-          vendor/bin/php-cs-fixer fix tests --rules=@Symfony --dry-run --diff
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff
 
   minimal-install:
     name: Minimal production install
@@ -57,6 +55,60 @@ jobs:
 
       - name: Compile without optional integrations
         run: php tests/minimal-install.php
+
+  consumer-application:
+    name: Consumer / ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Symfony 7.4
+            php: "8.3"
+            symfony: "~7.4.0"
+          - name: Symfony 8.0
+            php: "8.4"
+            symfony: "~8.0.0"
+    defaults:
+      run:
+        working-directory: tests/ConsumerApp
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: pdo_sqlite
+          coverage: none
+
+      - name: Select the Symfony branch
+        run: >-
+          composer require --no-update
+          "symfony/config:${{ matrix.symfony }}"
+          "symfony/console:${{ matrix.symfony }}"
+          "symfony/dependency-injection:${{ matrix.symfony }}"
+          "symfony/event-dispatcher:${{ matrix.symfony }}"
+          "symfony/filesystem:${{ matrix.symfony }}"
+          "symfony/finder:${{ matrix.symfony }}"
+          "symfony/framework-bundle:${{ matrix.symfony }}"
+          "symfony/http-foundation:${{ matrix.symfony }}"
+          "symfony/http-kernel:${{ matrix.symfony }}"
+          "symfony/messenger:${{ matrix.symfony }}"
+
+      - name: Install the bundle as an external dependency
+        run: composer update --prefer-dist --no-progress --no-interaction
+
+      - name: Validate shared database container
+        run: php bin/validate.php
+        env:
+          DATABASE_STRATEGY: shared_db
+
+      - name: Validate multi-database container
+        run: php bin/validate.php
+        env:
+          DATABASE_STRATEGY: multi_db
 
   compatibility:
     name: ${{ matrix.name }}
@@ -146,11 +198,21 @@ jobs:
 
       - name: Select supported dependency combination
         run: |
-          composer require --no-update "doctrine/doctrine-bundle:${{ matrix.doctrine_bundle }}"
-          composer require --dev --no-update \
-            "symfony/framework-bundle:${{ matrix.symfony }}" \
+          composer require --no-update \
+            "doctrine/doctrine-bundle:${{ matrix.doctrine_bundle }}" \
             "doctrine/orm:${{ matrix.orm }}" \
-            "doctrine/dbal:${{ matrix.dbal }}"
+            "doctrine/dbal:${{ matrix.dbal }}" \
+            "symfony/config:${{ matrix.symfony }}" \
+            "symfony/console:${{ matrix.symfony }}" \
+            "symfony/dependency-injection:${{ matrix.symfony }}" \
+            "symfony/event-dispatcher:${{ matrix.symfony }}" \
+            "symfony/filesystem:${{ matrix.symfony }}" \
+            "symfony/finder:${{ matrix.symfony }}" \
+            "symfony/http-foundation:${{ matrix.symfony }}" \
+            "symfony/http-kernel:${{ matrix.symfony }}" \
+            "symfony/messenger:${{ matrix.symfony }}"
+          composer require --dev --no-update \
+            "symfony/framework-bundle:${{ matrix.symfony }}"
 
       - name: Resolve dependencies
         run: |

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,17 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in([
+        __DIR__."/src",
+        __DIR__."/tests",
+    ])
+    ->exclude([
+        "ConsumerApp/var",
+        "ConsumerApp/vendor",
+    ])
+;
+
+return (new PhpCsFixer\Config())
+    ->setRules(["@Symfony" => true])
+    ->setFinder($finder)
+;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Persisted the PostgreSQL tenant setting for the database session and clear stale tenant state when no context is active.
 
 ### Added
+- Added an external consumer application that compiles shared and multi-database configurations on Symfony 7.4 and 8.0.
 - Replaced Symfony ORM and test packs with direct component requirements and added a production-only minimal installation check.
 - Documented required, optional, suggested, and development-only dependencies.
 - Added a required PHP 8.3–8.5, Symfony 7.4/8.0, Doctrine ORM 3.5/3.6, and DBAL 3.8/4.4 compatibility matrix.

--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,10 @@ test-decorators: ## Run decorator tests
 
 ## —— 🧪 QA tools ———————————————————————————————————————————————————————————————————————————
 csfixer: ## Run PHP-CS-Fixer on src/ and tests/
-	$(DOCKER_RUN) vendor/bin/php-cs-fixer fix src --rules=@Symfony --verbose
-	$(DOCKER_RUN) vendor/bin/php-cs-fixer fix tests --rules=@Symfony --verbose
+	$(DOCKER_RUN) vendor/bin/php-cs-fixer fix --verbose
 
 csfixer-check: ## Check code style without fixing
-	$(DOCKER_RUN) vendor/bin/php-cs-fixer fix src --rules=@Symfony --dry-run --diff
-	$(DOCKER_RUN) vendor/bin/php-cs-fixer fix tests --rules=@Symfony --dry-run --diff
+	$(DOCKER_RUN) vendor/bin/php-cs-fixer fix --dry-run --diff
 
 phpstan: ## Run PHPStan static analysis
 	$(DOCKER_RUN) vendor/bin/phpstan analyse src -c phpstan.neon --memory-limit=512M

--- a/README.md
+++ b/README.md
@@ -95,13 +95,15 @@ Create `config/packages/zhortein_multi_tenant.yaml`:
 ```yaml
 zhortein_multi_tenant:
     tenant_entity: 'App\Entity\Tenant'
-    resolver:
-        type: 'subdomain'
-        options:
-            base_domain: 'example.com'
     database:
         strategy: 'shared_db'
         enable_filter: true
+        rls:
+            enabled: false
+    fixtures:
+        enabled: false
+    mailer:
+        enabled: false
 ```
 
 ### 3. Create Tenant-Aware Entities

--- a/docs/audit-2026-07.md
+++ b/docs/audit-2026-07.md
@@ -41,6 +41,8 @@ Those changes already remove `doctrine/annotations`, correct suspicious Composer
 
 PHP 8.4/8.5, Symfony 7.4/8, and supported Doctrine combinations are not confirmed. Production requirements should name the components actually used, while optional integrations should remain optional. The concrete Monolog dependency should also be reviewed in favor of PSR contracts where possible.
 
+A standalone Composer consumer fixture now installs a non-symlinked package copy and compiles both database strategies on Symfony 7.4 and 8.0.
+
 Resolved on 2026-07-31: the compatibility matrix now verifies the announced PHP, Symfony, DoctrineBundle, ORM, and DBAL combinations. Symfony packs were replaced with direct component requirements, Monolog and Mailer are optional, and a production-only CI job compiles the container without Mailer, Twig, Monolog, or PSR-16. See [Dependency Classification](dependencies.md).
 
 The production PSR-4 mapping is coherent. The advertised test kit is under `autoload-dev` and is therefore not normally available to consuming applications.

--- a/tests/ConsumerApp/.gitignore
+++ b/tests/ConsumerApp/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+/var/cache/*
+!/var/cache/.gitkeep
+composer.lock

--- a/tests/ConsumerApp/README.md
+++ b/tests/ConsumerApp/README.md
@@ -1,0 +1,14 @@
+# Consumer Application Fixture
+
+This fixture is a standalone Symfony application used only for compatibility validation. Its Composer path repository disables symlinks, so the bundle is copied under the fixture vendor directory and behaves like an external dependency.
+
+GitHub Actions selects Symfony 7.4 or 8.0, installs the fixture dependencies, and boots separate `shared_db` and `multi_db` kernels. Both configurations must compile without Mailer, Twig, Monolog, or PSR-16.
+
+From the repository root, reproduce the PHP 8.3 and Symfony 7.4 scenario with:
+
+```bash
+docker run --rm -v "$PWD":/workspace -w /workspace/tests/ConsumerApp composer:2 composer update --prefer-dist --no-progress --no-interaction
+docker run --rm -v "$PWD":/workspace -w /workspace/tests/ConsumerApp php:8.3-cli php bin/validate.php
+```
+
+Use an isolated copy if a different dependency resolution is already present in the fixture.

--- a/tests/ConsumerApp/bin/validate.php
+++ b/tests/ConsumerApp/bin/validate.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Kernel;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+$installedBundle = dirname(__DIR__).'/vendor/zhortein/multi-tenant-bundle';
+if (!is_dir($installedBundle) || is_link($installedBundle)) {
+    throw new RuntimeException('The bundle must be installed as an external, non-symlinked Composer dependency.');
+}
+
+$strategy = $_SERVER['DATABASE_STRATEGY'] ?? 'shared_db';
+$kernel = new Kernel('test_'.$strategy, false);
+$kernel->boot();
+$container = $kernel->getContainer();
+
+if ($container->getParameter('zhortein_multi_tenant.database.strategy') !== $strategy) {
+    throw new RuntimeException(sprintf('The %s database strategy was not compiled.', $strategy));
+}
+
+if ("App\Entity\Tenant" !== $container->getParameter('zhortein_multi_tenant.tenant_entity')) {
+    throw new RuntimeException('The consumer tenant entity was not compiled.');
+}
+
+$kernel->shutdown();
+echo sprintf("Consumer container compiled for %s.\n", $strategy);

--- a/tests/ConsumerApp/composer.json
+++ b/tests/ConsumerApp/composer.json
@@ -1,0 +1,37 @@
+{
+  "name": "zhortein/multi-tenant-consumer-fixture",
+  "type": "project",
+  "description": "External consumer fixture for bundle compatibility tests",
+  "license": "proprietary",
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../..",
+      "options": {
+        "symlink": false
+      }
+    }
+  ],
+  "require": {
+    "php": ">=8.3",
+    "symfony/config": "~7.4.0",
+    "symfony/console": "~7.4.0",
+    "symfony/dependency-injection": "~7.4.0",
+    "symfony/event-dispatcher": "~7.4.0",
+    "symfony/filesystem": "~7.4.0",
+    "symfony/finder": "~7.4.0",
+    "symfony/framework-bundle": "~7.4.0",
+    "symfony/http-foundation": "~7.4.0",
+    "symfony/http-kernel": "~7.4.0",
+    "symfony/messenger": "~7.4.0",
+    "zhortein/multi-tenant-bundle": "@dev"
+  },
+  "autoload": {
+    "psr-4": {
+      "App\\": "src/"
+    }
+  },
+  "config": {
+    "sort-packages": true
+  }
+}

--- a/tests/ConsumerApp/src/Entity/Tenant.php
+++ b/tests/ConsumerApp/src/Entity/Tenant.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Zhortein\MultiTenantBundle\Entity\TenantInterface;
+
+#[ORM\Entity]
+class Tenant implements TenantInterface
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    private string $id = 'fixture';
+
+    #[ORM\Column(unique: true)]
+    private string $slug = 'fixture';
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function getName(): string
+    {
+        return 'Consumer Fixture';
+    }
+
+    public function getDomain(): ?string
+    {
+        return null;
+    }
+
+    public function isActive(): bool
+    {
+        return true;
+    }
+
+    public function getMailerDsn(): ?string
+    {
+        return null;
+    }
+
+    public function getMessengerDsn(): ?string
+    {
+        return null;
+    }
+}

--- a/tests/ConsumerApp/src/Kernel.php
+++ b/tests/ConsumerApp/src/Kernel.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Zhortein\MultiTenantBundle\ZhorteinMultiTenantBundle;
+
+final class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+
+    public function registerBundles(): iterable
+    {
+        yield new FrameworkBundle();
+        yield new DoctrineBundle();
+        yield new DoctrineMigrationsBundle();
+        yield new ZhorteinMultiTenantBundle();
+    }
+
+    public function getProjectDir(): string
+    {
+        return dirname(__DIR__);
+    }
+
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
+    {
+        $strategy = $_SERVER['DATABASE_STRATEGY'] ?? 'shared_db';
+
+        $container->loadFromExtension('framework', [
+            'secret' => 'consumer-fixture-secret',
+            'test' => true,
+        ]);
+        $container->loadFromExtension('doctrine', [
+            'dbal' => ['url' => 'sqlite:///%kernel.cache_dir%/consumer.db'],
+            'orm' => [
+                'mappings' => [
+                    'App' => [
+                        'type' => 'attribute',
+                        'dir' => '%kernel.project_dir%/src/Entity',
+                        'prefix' => "App\Entity",
+                    ],
+                ],
+            ],
+        ]);
+        $container->loadFromExtension('doctrine_migrations', [
+            'migrations_paths' => ['DoctrineMigrations' => '%kernel.project_dir%/migrations'],
+        ]);
+        $container->loadFromExtension('zhortein_multi_tenant', [
+            'tenant_entity' => "App\Entity\Tenant",
+            'database' => [
+                'strategy' => $strategy,
+                'rls' => ['enabled' => false],
+            ],
+            'decorators' => [
+                'cache' => ['enabled' => false],
+                'logger' => ['enabled' => false],
+            ],
+            'fixtures' => ['enabled' => false],
+            'mailer' => ['enabled' => false],
+            'storage' => ['enabled' => false],
+        ]);
+    }
+}


### PR DESCRIPTION
Closes #8

## Problem

The bundle test suite compiled an in-repository kernel, but did not prove that a real Symfony application could install the package as an external dependency. Documentation examples and dependency selection could therefore drift without detection.

## Solution and architecture

- Add a standalone Composer consumer fixture that installs the bundle as a copied, non-symlinked path dependency.
- Boot independent kernels for `shared_db` and `multi_db` and assert the compiled public parameters.
- Run the fixture on Symfony 7.4/PHP 8.3 and Symfony 8.0/PHP 8.4 in GitHub Actions.
- Pin every direct Symfony component in compatibility jobs so each cell resolves a coherent framework branch.
- Centralize PHP-CS-Fixer discovery and exclude only generated fixture `vendor` and cache directories.
- Replace the invalid nested resolver snippet in the quick start with the configuration tree exercised by the consumer fixture.

## Compatibility

This is additive and does not change runtime APIs, defaults, or the supported compatibility matrix. The fixture explicitly verifies both currently supported Symfony branches and both database strategies without optional Mailer, Twig, Monolog, or PSR-16 services.

## Tests

- `make composer-validate`
- `make phpstan` (level max)
- `make csfixer-check`
- `make test` (410 tests, 1,037 assertions; 76 environment-dependent skips and 263 notices)
- `make test-with-postgres` (10 tests, 30 assertions)
- `composer audit --no-interaction --abandoned=report`
- External consumer compilation on Symfony 7.4 and 8.0, for `shared_db` and `multi_db`

## Migration impact

None.