### PR TITLE
Stabilize resolver configuration and Symfony 8.1 support

### DIFF
--- a/.github/workflows/test-kit.yml
+++ b/.github/workflows/test-kit.yml
@@ -69,6 +69,9 @@ jobs:
           - name: Symfony 8.0
             php: "8.4"
             symfony: "~8.0.0"
+          - name: Symfony 8.1
+            php: "8.5"
+            symfony: "~8.1.0"
     defaults:
       run:
         working-directory: tests/ConsumerApp
@@ -155,6 +158,13 @@ jobs:
           - name: PHP 8.5 / Symfony 8.0 / ORM 3.6 / DBAL 4.4
             php: '8.5'
             symfony: '~8.0.0'
+            orm: '^3.6'
+            dbal: '^4.4'
+            doctrine_bundle: ^3.3
+            dependencies: highest
+          - name: PHP 8.5 / Symfony 8.1 / ORM 3.6 / DBAL 4.4
+            php: '8.5'
+            symfony: '~8.1.0'
             orm: '^3.6'
             dbal: '^4.4'
             doctrine_bundle: ^3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0-RC3] - 2026-04-05
 
 ### Fixed
+- Corrected historically invalid `resolver.type` and `resolution.strategy` documentation examples to the only supported scalar `resolver` syntax; invalid nested structures now fail with actionable errors.
 - Declared the PSR Simple Cache 3 requirement used by the optional typed PSR-16 decorator and updated Console tests for Symfony 8.
 - Replaced the false-positive RLS target with six effective PostgreSQL 16 tests using a non-superuser application role and raw DBAL queries.
 - Persisted the PostgreSQL tenant setting for the database session and clear stale tenant state when no context is active.
 
 ### Added
-- Added an external consumer application that compiles shared and multi-database configurations on Symfony 7.4 and 8.0.
+- Added required Symfony 8.1 and PHP 8.5 compatibility and external consumer jobs while retaining Symfony 7.4 LTS and Symfony 8.0 lower-bound coverage.
+- Added an external consumer application that compiles shared and multi-database configurations on Symfony 7.4, 8.0, and 8.1.
 - Replaced Symfony ORM and test packs with direct component requirements and added a production-only minimal installation check.
 - Documented required, optional, suggested, and development-only dependencies.
-- Added a required PHP 8.3–8.5, Symfony 7.4/8.0, Doctrine ORM 3.5/3.6, and DBAL 3.8/4.4 compatibility matrix.
+- Added a required PHP 8.3–8.5, Symfony 7.4/8.0/8.1, Doctrine ORM 3.5/3.6, and DBAL 3.8/4.4 compatibility matrix.
 - Documented the supported combinations and compatibility removal policy.
 - **Symfony 8.0 & 7.4 Compatibility**
   - Updated `composer.json` to support Symfony `^7.4` and `^8.0` components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0-RC3] - 2026-04-05
 
 ### Fixed
+- Kept the tenant CLI test helper compatible with Symfony 8.1's public command assertion while preserving existing CommandTester calls.
 - Corrected historically invalid `resolver.type` and `resolution.strategy` documentation examples to the only supported scalar `resolver` syntax; invalid nested structures now fail with actionable errors.
 - Declared the PSR Simple Cache 3 requirement used by the optional typed PSR-16 decorator and updated Console tests for Symfony 8.
 - Replaced the false-positive RLS target with six effective PostgreSQL 16 tests using a non-superuser application role and raw DBAL queries.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zhortein Multi-Tenant Bundle
 
-A comprehensive Symfony 7.4+ and 8.0+ bundle for building multi-tenant applications with PostgreSQL 16 support.
+A comprehensive Symfony 7.4 LTS and Symfony 8.x bundle for building multi-tenant applications with PostgreSQL 16 support.
 
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D8.3-blue.svg)](https://php.net/)
 [![Symfony Version](https://img.shields.io/badge/symfony-%3E%3D7.4%20%7C%208.0-green.svg)](https://symfony.com/)

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "zhortein/multi-tenant-bundle",
   "type": "symfony-bundle",
-  "description": "A comprehensive Symfony 7.4+ and 8.0+ bundle for building multi-tenant applications with PostgreSQL 16 support, featuring multiple resolution strategies, tenant-aware services, and automatic database filtering.",
+  "description": "A comprehensive Symfony 7.4 LTS and Symfony 8.x bundle for building multi-tenant applications with PostgreSQL 16 support, featuring multiple resolution strategies, tenant-aware services, and automatic database filtering.",
   "keywords": ["symfony", "symfony-bundle", "multi-tenant", "multitenant", "tenant", "multi-tenancy", "subdomain", "domain", "dns", "postgresql", "doctrine", "orm", "mailer", "messenger", "storage", "saas", "hosting"],
   "homepage": "https://github.com/zhortein/multi-tenant-bundle",
   "license": "MIT",
@@ -50,11 +50,12 @@
     "phpunit/phpunit": "^12.2.5",
     "psr/simple-cache": "^3.0",
     "roave/security-advisories": "dev-latest",
-    "symfony/mailer": "^7.4 || ^8.0",
-    "symfony/phpunit-bridge": "^7.4 || ^8.0",
     "symfony/browser-kit": "^7.4 || ^8.0",
     "symfony/dom-crawler": "^7.4 || ^8.0",
-    "symfony/twig-bundle": "^7.4 || ^8.0"
+    "symfony/mailer": "^7.4 || ^8.0",
+    "symfony/phpunit-bridge": "^7.4 || ^8.0",
+    "symfony/twig-bundle": "^7.4 || ^8.0",
+    "symfony/yaml": "^7.4 || ^8.0"
   },
   "config": {
     "sort-packages": true

--- a/docs/audit-2026-07.md
+++ b/docs/audit-2026-07.md
@@ -41,7 +41,7 @@ Those changes already remove `doctrine/annotations`, correct suspicious Composer
 
 PHP 8.4/8.5, Symfony 7.4/8, and supported Doctrine combinations are not confirmed. Production requirements should name the components actually used, while optional integrations should remain optional. The concrete Monolog dependency should also be reviewed in favor of PSR contracts where possible.
 
-A standalone Composer consumer fixture now installs a non-symlinked package copy and compiles both database strategies on Symfony 7.4 and 8.0.
+A standalone Composer consumer fixture now installs a non-symlinked package copy and compiles both database strategies on Symfony 7.4, 8.0, and 8.1.
 
 Resolved on 2026-07-31: the compatibility matrix now verifies the announced PHP, Symfony, DoctrineBundle, ORM, and DBAL combinations. Symfony packs were replaced with direct component requirements, Monolog and Mailer are optional, and a production-only CI job compiles the container without Mailer, Twig, Monolog, or PSR-16. See [Dependency Classification](dependencies.md).
 
@@ -76,7 +76,7 @@ The production PSR-4 mapping is coherent. The advertised test kit is under `auto
 
 ## Defects and documentation debt
 
-- The quick start documents `resolver.type`, while the configuration tree expects a scalar `resolver`.
+- Resolved on 2026-07-31: historical examples using `resolver.type` and the demo's `resolution.strategy` were corrected to the only effective syntax, the scalar `resolver`. Configuration tests cover all nine supported values and reject both invalid nested structures with actionable errors.
 - The README imports `Entity\TenantAwareEntityTrait`, which does not exist; relevant traits are under `Doctrine`.
 - Several guides repeat the obsolete resolver shape or options absent from the configuration tree.
 - `config/services.yaml` contains Doctrine resource paths and a global connection-factory replacement that require validation in a minimal app.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -12,8 +12,9 @@ Every supported combination is resolved from `composer.json` and exercised in Gi
 | 8.4 | 8.0 | 3.3 | 3.6 | 4.4 | Latest supported versions |
 | 8.5 | 7.4 | 3.3 | 3.6 | 4.4 | Latest supported versions |
 | 8.5 | 8.0 | 3.3 | 3.6 | 4.4 | Latest supported versions |
+| 8.5 | 8.1 | 3.3 | 3.6 | 4.4 | Current Symfony 8 branch |
 
-Symfony 8 is not tested on PHP 8.3 because Symfony 8 requires PHP 8.4 or later. DoctrineBundle 2.19 preserves the PHP 8.3 path, while DoctrineBundle 3.3 provides the Symfony 8-compatible path on PHP 8.4 and later. Doctrine DBAL 3 support is exercised with the oldest supported ORM line, while DBAL 4 is exercised with the current ORM line.
+Symfony 8 is not tested on PHP 8.3 because Symfony 8 requires PHP 8.4 or later. Symfony 8.0 remains in the matrix as the lower bound of the supported `^8.0` constraint even though its normal support window has ended; Symfony 8.1 on PHP 8.5 is the required current Symfony 8 combination. DoctrineBundle 2.19 preserves the PHP 8.3 path, while DoctrineBundle 3.3 provides the Symfony 8-compatible path on PHP 8.4 and later. Doctrine DBAL 3 support is exercised with the oldest supported ORM line, while DBAL 4 is exercised with the current ORM line.
 
 The lowest cell resolves runtime packages with `--prefer-lowest`, then updates PHPStan and its extensions so current static-analysis rules evaluate that runtime graph.
 
@@ -22,7 +23,7 @@ Each matrix cell runs strict Composer validation, a dependency security audit, P
 ## Version policy
 
 - PHP versions are supported while they receive upstream security fixes and remain compatible with a supported Symfony branch.
-- Symfony 7.4 and 8.0 are the supported framework branches.
+- Symfony 7.4 LTS and Symfony 8.1 are the actively supported framework branches. Symfony 8.0 remains verified as the lower compatibility bound of the `^8.0` constraint.
 - Doctrine ORM 3.5 and later within the 3.x line are supported.
 - Doctrine DBAL 3.8 and the 4.x line are supported through explicitly tested combinations.
 - PostgreSQL 16 is the reference database for RLS guarantees.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,17 @@
 # Configuration Reference
 
+## Canonical resolver syntax
+
+The `resolver` option is a scalar. Supported values are `path`, `subdomain`, `header`, `query`, `domain`, `hybrid`, `dns_txt`, `chain`, and `custom`.
+
+~~~yaml
+zhortein_multi_tenant:
+    resolver: 'path'
+~~~
+
+Older examples using `resolver.type` or `resolution.strategy` were documentation errors and never matched the effective configuration tree. They are not compatibility aliases and are rejected with an actionable configuration error.
+
+
 This document provides a complete reference for configuring the Zhortein Multi-Tenant Bundle.
 
 > 📖 **Navigation**: [← Back to Documentation Index](index.md) | [Installation Guide →](installation.md)
@@ -259,13 +271,13 @@ Then register your custom resolver service:
 ```yaml
 # config/services.yaml
 services:
-    app.custom_tenant_resolver:
-        class: App\Resolver\CustomTenantResolver
-        tags:
-            - { name: 'zhortein_multi_tenant.resolver', alias: 'custom' }
+    App\Resolver\CustomTenantResolver: ~
+
+    Zhortein\MultiTenantBundle\Resolver\TenantResolverInterface:
+        alias: App\Resolver\CustomTenantResolver
 ```
 
-Your custom resolver must implement `TenantResolverInterface`.
+Your custom resolver must implement `TenantResolverInterface`. The bundle does not collect tagged custom resolvers.
 
 ## Database Strategies
 

--- a/docs/examples/database-usage.md
+++ b/docs/examples/database-usage.md
@@ -986,10 +986,9 @@ doctrine:
 # config/packages/zhortein_multi_tenant.yaml
 zhortein_multi_tenant:
     tenant_entity: 'App\Entity\Tenant'
-    resolver:
-        type: 'subdomain'
-        options:
-            header_name: 'X-Tenant-ID'
+    resolver: 'subdomain'
+    subdomain:
+        base_domain: 'example.com'
     database:
         enabled: true
         dispatch_database_switch: true

--- a/docs/examples/resolver-chain-usage.md
+++ b/docs/examples/resolver-chain-usage.md
@@ -104,54 +104,19 @@ class TenantController
 }
 ```
 
-### Example 4: Custom Resolver in Chain
+### Example 4: Application-Specific Composite Resolver
 
-```php
-<?php
-
-use Zhortein\MultiTenantBundle\Resolver\TenantResolverInterface;
-
-class JwtTenantResolver implements TenantResolverInterface
-{
-    public function __construct(
-        private TenantRegistryInterface $tenantRegistry,
-        private JwtDecoderInterface $jwtDecoder
-    ) {}
-    
-    public function resolveTenant(Request $request): ?TenantInterface
-    {
-        $token = $request->headers->get('Authorization');
-        
-        if (!$token || !str_starts_with($token, 'Bearer ')) {
-            return null;
-        }
-        
-        try {
-            $payload = $this->jwtDecoder->decode(substr($token, 7));
-            $tenantId = $payload['tenant_id'] ?? null;
-            
-            return $tenantId ? $this->tenantRegistry->getById($tenantId) : null;
-        } catch (\Exception) {
-            return null;
-        }
-    }
-}
-```
+Custom names cannot be added to `resolver_chain.order`. Implement application-specific composition behind `TenantResolverInterface` and select the custom strategy:
 
 ```yaml
-# Register custom resolver
 services:
-    App\Resolver\JwtTenantResolver:
-        arguments:
-            $tenantRegistry: '@zhortein_multi_tenant.tenant_registry'
-            $jwtDecoder: '@app.jwt_decoder'
+    App\Resolver\JwtThenSubdomainResolver: ~
 
-# Use in chain
+    Zhortein\MultiTenantBundle\Resolver\TenantResolverInterface:
+        alias: App\Resolver\JwtThenSubdomainResolver
+
 zhortein_multi_tenant:
-    resolver: chain
-    resolver_chain:
-        order: [jwt, subdomain, header]
-        strict: false
+    resolver: 'custom'
 ```
 
 ## Request Examples

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -131,10 +131,9 @@ $settingsManager->set('email_from', 'noreply@tenant.com');
 
 ```yaml
 zhortein_multi_tenant:
-    resolver:
-        type: 'subdomain'
-        options:
-            base_domain: 'example.com'
+    resolver: 'subdomain'
+    subdomain:
+        base_domain: 'example.com'
 ```
 
 ## Development & Testing

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Zhortein Multi-Tenant Bundle Documentation
 
-Welcome to the comprehensive documentation for the Zhortein Multi-Tenant Bundle, a powerful Symfony 7.4+ and 8.0+ solution for building multi-tenant applications with PostgreSQL 16 support.
+Welcome to the comprehensive documentation for the Zhortein Multi-Tenant Bundle, a powerful Symfony 7.4 LTS and Symfony 8.x solution for building multi-tenant applications with PostgreSQL 16 support.
 
 > 📖 **Quick Start**: New to the bundle? Check out the [main README](../README.md) for installation and quick start guide.
 
@@ -63,7 +63,7 @@ Welcome to the comprehensive documentation for the Zhortein Multi-Tenant Bundle,
 
 ## Overview
 
-The Zhortein Multi-Tenant Bundle provides a comprehensive, production-ready solution for building multi-tenant applications with Symfony 7.4+ and 8.0+. It follows Symfony best practices and includes extensive testing and documentation.
+The Zhortein Multi-Tenant Bundle provides a comprehensive, production-ready solution for building multi-tenant applications with Symfony 7.4 LTS and Symfony 8.x. It follows Symfony best practices and includes extensive testing and documentation.
 
 ### Key Features
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation & Setup
 
-This guide walks you through installing and configuring the Zhortein Multi-Tenant Bundle for Symfony 7.4+ and 8.0+ applications.
+This guide walks you through installing and configuring the Zhortein Multi-Tenant Bundle for Symfony 7.4 LTS and Symfony 8.x applications.
 
 > 📖 **Navigation**: [← Back to Documentation Index](index.md) | [Configuration →](configuration.md)
 
@@ -140,10 +140,9 @@ zhortein_multi_tenant:
     tenant_entity: 'App\Entity\Tenant'
     
     # Tenant resolution strategy
-    resolver:
-        type: 'subdomain'  # 'subdomain', 'path', 'header', or 'custom'
-        options:
-            base_domain: 'example.com'
+    resolver: 'subdomain'
+    subdomain:
+        base_domain: 'example.com'
     
     # Database strategy
     database:

--- a/docs/resolver-chain.md
+++ b/docs/resolver-chain.md
@@ -31,7 +31,9 @@ zhortein_multi_tenant:
 | `header_allow_list` | array | `[X-Tenant-Id, X-Tenant-Slug]` | Allowed header names for header resolvers |
 
 ### Individual Resolver Configuration
-   
+
+The `order` list accepts only the seven built-in resolver names shown below. Unknown names fail configuration processing instead of being silently skipped. Custom composition belongs behind a `TenantResolverInterface` service selected with `resolver: 'custom'`.
+
 Each resolver in the chain can be configured independently:
 
 ```yaml
@@ -41,18 +43,18 @@ zhortein_multi_tenant:
         order: [subdomain, header, query, path]
         strict: false
         header_allow_list: ["X-Tenant-Id"]
-    
+
     # Configure individual resolvers
     subdomain:
         base_domain: 'myapp.com'
         excluded_subdomains: ['www', 'api', 'admin']
-    
+
     header:
         name: 'X-Tenant-Id'
-    
+
     query:
         parameter: 'tenant'
-    
+
     # Path resolver uses default configuration
 ```
 
@@ -222,10 +224,10 @@ zhortein_multi_tenant:
         order: [subdomain, header]
         strict: false
         header_allow_list: ["X-Tenant-Id"]
-    
+
     subdomain:
         base_domain: 'myapp.com'
-    
+
     header:
         name: 'X-Tenant-Id'
 ```
@@ -244,10 +246,10 @@ zhortein_multi_tenant:
         order: [header, query]
         strict: true
         header_allow_list: ["X-Tenant-Id"]
-    
+
     header:
         name: 'X-Tenant-Id'
-    
+
     query:
         parameter: 'tenant'
 ```
@@ -266,10 +268,10 @@ zhortein_multi_tenant:
         order: [header, query, path]
         strict: false
         header_allow_list: ["X-Tenant-Id", "Authorization"]
-    
+
     header:
         name: 'X-Tenant-Id'
-    
+
     query:
         parameter: 'tenant_id'
 ```

--- a/docs/tenant-resolution.md
+++ b/docs/tenant-resolution.md
@@ -15,11 +15,10 @@ Resolves tenants based on the subdomain of the request URL.
 ```yaml
 # config/packages/zhortein_multi_tenant.yaml
 zhortein_multi_tenant:
-    resolver:
-        type: 'subdomain'
-        options:
-            base_domain: 'example.com'
-            excluded_subdomains: ['www', 'api', 'admin', 'mail', 'ftp']
+    resolver: 'subdomain'
+    subdomain:
+        base_domain: 'example.com'
+        excluded_subdomains: ['www', 'api', 'admin', 'mail', 'ftp']
 ```
 
 **Examples:**
@@ -65,10 +64,7 @@ Resolves tenants based on the first segment of the URL path.
 ```yaml
 # config/packages/zhortein_multi_tenant.yaml
 zhortein_multi_tenant:
-    resolver:
-        type: 'path'
-        options:
-            position: 1 # Position in path (1-based)
+    resolver: 'path'
 ```
 
 **Examples:**
@@ -126,10 +122,9 @@ Resolves tenants based on HTTP headers.
 ```yaml
 # config/packages/zhortein_multi_tenant.yaml
 zhortein_multi_tenant:
-    resolver:
-        type: 'header'
-        options:
-            header_name: 'X-Tenant-ID'
+    resolver: 'header'
+    header:
+        name: 'X-Tenant-ID'
 ```
 
 **Examples:**
@@ -396,9 +391,10 @@ class DatabaseTenantResolver implements TenantResolverInterface
 ```yaml
 # config/services.yaml
 services:
-    App\Resolver\DatabaseTenantResolver:
-        tags:
-            - { name: 'zhortein.tenant_resolver', priority: 10 }
+    App\Resolver\DatabaseTenantResolver: ~
+
+    Zhortein\MultiTenantBundle\Resolver\TenantResolverInterface:
+        alias: App\Resolver\DatabaseTenantResolver
 ```
 
 **Configuration:**
@@ -406,9 +402,7 @@ services:
 ```yaml
 # config/packages/zhortein_multi_tenant.yaml
 zhortein_multi_tenant:
-    resolver:
-        type: 'custom'
-        service: 'App\Resolver\DatabaseTenantResolver'
+    resolver: 'custom'
 ```
 
 ## Advanced Custom Resolvers
@@ -551,23 +545,9 @@ class DomainMappingTenantResolver implements TenantResolverInterface
 }
 ```
 
-## Resolver Priority
+## Custom Composition
 
-When multiple resolvers are registered, they are executed in priority order:
-
-```yaml
-# config/services.yaml
-services:
-    App\Resolver\PrimaryResolver:
-        tags:
-            - { name: 'zhortein.tenant_resolver', priority: 100 }
-    
-    App\Resolver\FallbackResolver:
-        tags:
-            - { name: 'zhortein.tenant_resolver', priority: 10 }
-```
-
-Higher priority resolvers are executed first. The first resolver that returns a tenant wins.
+The built-in chain accepts only `path`, `subdomain`, `header`, `query`, `domain`, `hybrid`, and `dns_txt`. It does not collect tagged services. To combine application-specific resolvers, implement that composition in one `TenantResolverInterface` service, select `resolver: 'custom'`, and alias the interface to that service.
 
 ## Configuration Options
 
@@ -580,21 +560,10 @@ zhortein_multi_tenant:
     tenant_entity: 'App\Entity\Tenant'
     
     # Resolver configuration
-    resolver:
-        type: 'subdomain' # subdomain, path, header, or custom
-        options:
-            # Subdomain resolver options
-            base_domain: 'example.com'
-            excluded_subdomains: ['www', 'api', 'admin']
-            
-            # Path resolver options
-            position: 1
-            
-            # Header resolver options
-            header_name: 'X-Tenant-ID'
-            
-            # Custom resolver options
-            service: 'App\Resolver\CustomResolver'
+    resolver: 'subdomain'
+    subdomain:
+        base_domain: 'example.com'
+        excluded_subdomains: ['www', 'api', 'admin']
     
     # Default tenant (optional)
     default_tenant: null
@@ -608,17 +577,13 @@ zhortein_multi_tenant:
 ```yaml
 # config/packages/dev/zhortein_multi_tenant.yaml
 zhortein_multi_tenant:
-    resolver:
-        type: 'path' # Use path resolver in development
-        options:
-            position: 1
+    resolver: 'path' # Use path resolver in development
 
 # config/packages/prod/zhortein_multi_tenant.yaml
 zhortein_multi_tenant:
-    resolver:
-        type: 'subdomain' # Use subdomain resolver in production
-        options:
-            base_domain: '%env(APP_DOMAIN)%'
+    resolver: 'subdomain' # Use subdomain resolver in production
+    subdomain:
+        base_domain: '%env(APP_DOMAIN)%'
 ```
 
 ## Testing Resolvers

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -6,6 +6,7 @@ namespace Zhortein\MultiTenantBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
  * Configuration definition for the multi-tenant bundle.
@@ -23,6 +24,12 @@ final class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('zhortein_multi_tenant');
 
         $treeBuilder->getRootNode()
+            ->beforeNormalization()
+                ->ifTrue(static fn (mixed $value): bool => is_array($value) && array_key_exists('resolution', $value))
+                ->then(static function (mixed $value): never {
+                    throw new InvalidConfigurationException('The "resolution" option has never been supported. Use the scalar "resolver: path" syntax instead.');
+                })
+            ->end()
             ->children()
                 // Tenant entity configuration
                 ->scalarNode('tenant_entity')
@@ -32,6 +39,12 @@ final class Configuration implements ConfigurationInterface
 
                 // Tenant resolver configuration
                 ->enumNode('resolver')
+                    ->beforeNormalization()
+                        ->ifArray()
+                        ->then(static function (mixed $value): never {
+                            throw new InvalidConfigurationException('The "resolver" option must be a scalar. Use "resolver: path" instead of the unsupported "resolver.type" structure.');
+                        })
+                    ->end()
                     ->values(['path', 'subdomain', 'header', 'query', 'domain', 'hybrid', 'dns_txt', 'chain', 'custom'])
                     ->defaultValue('path')
                     ->info('The tenant resolution strategy to use')
@@ -42,7 +55,9 @@ final class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->arrayNode('order')
-                            ->scalarPrototype()->end()
+                            ->enumPrototype()
+                                ->values(['path', 'subdomain', 'header', 'query', 'domain', 'hybrid', 'dns_txt'])
+                            ->end()
                             ->defaultValue(['subdomain', 'path', 'header', 'query'])
                             ->info('Order of resolvers to try in the chain')
                         ->end()

--- a/tests/ConsumerApp/README.md
+++ b/tests/ConsumerApp/README.md
@@ -2,7 +2,7 @@
 
 This fixture is a standalone Symfony application used only for compatibility validation. Its Composer path repository disables symlinks, so the bundle is copied under the fixture vendor directory and behaves like an external dependency.
 
-GitHub Actions selects Symfony 7.4 or 8.0, installs the fixture dependencies, and boots separate `shared_db` and `multi_db` kernels. Both configurations must compile without Mailer, Twig, Monolog, or PSR-16.
+GitHub Actions selects Symfony 7.4, 8.0, or 8.1, installs the fixture dependencies, and boots separate `shared_db` and `multi_db` kernels. Both configurations must compile without Mailer, Twig, Monolog, or PSR-16.
 
 From the repository root, reproduce the PHP 8.3 and Symfony 7.4 scenario with:
 
@@ -11,4 +11,4 @@ docker run --rm -v "$PWD":/workspace -w /workspace/tests/ConsumerApp composer:2 
 docker run --rm -v "$PWD":/workspace -w /workspace/tests/ConsumerApp php:8.3-cli php bin/validate.php
 ```
 
-Use an isolated copy if a different dependency resolution is already present in the fixture.
+The Symfony 8.1 job resolves the same direct components at `~8.1.0` and executes both validations with PHP 8.5. Use an isolated copy if a different dependency resolution is already present in the fixture.

--- a/tests/Toolkit/TenantCliTestCase.php
+++ b/tests/Toolkit/TenantCliTestCase.php
@@ -9,6 +9,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Tester\ExecutionResult;
 use Zhortein\MultiTenantBundle\Context\TenantContextInterface;
 use Zhortein\MultiTenantBundle\Registry\TenantRegistryInterface;
 
@@ -202,11 +203,11 @@ abstract class TenantCliTestCase extends KernelTestCase
      *
      * @param CommandTester $commandTester The command tester
      */
-    public function assertCommandIsSuccessful(CommandTester|string $commandTester = ''): void
+    public function assertCommandIsSuccessful(CommandTester|ExecutionResult $commandTester, string $message = ''): void
     {
-        if (is_string($commandTester)) {
+        if ($commandTester instanceof ExecutionResult) {
             $parentMethod = new \ReflectionMethod(parent::class, __FUNCTION__);
-            $parentMethod->invoke($this, $commandTester);
+            $parentMethod->invoke($this, $commandTester, $message);
 
             return;
         }
@@ -214,7 +215,7 @@ abstract class TenantCliTestCase extends KernelTestCase
         $this->assertSame(
             Command::SUCCESS,
             $commandTester->getStatusCode(),
-            sprintf('Command failed with output: %s', $commandTester->getDisplay())
+            $message ?: sprintf('Command failed with output: %s', $commandTester->getDisplay())
         );
     }
 

--- a/tests/Toolkit/TenantCliTestCase.php
+++ b/tests/Toolkit/TenantCliTestCase.php
@@ -202,8 +202,15 @@ abstract class TenantCliTestCase extends KernelTestCase
      *
      * @param CommandTester $commandTester The command tester
      */
-    protected function assertCommandIsSuccessful(CommandTester $commandTester): void
+    public function assertCommandIsSuccessful(CommandTester|string $commandTester = ''): void
     {
+        if (is_string($commandTester)) {
+            $parentMethod = new \ReflectionMethod(parent::class, __FUNCTION__);
+            $parentMethod->invoke($this, $commandTester);
+
+            return;
+        }
+
         $this->assertSame(
             Command::SUCCESS,
             $commandTester->getStatusCode(),

--- a/tests/Toolkit/TenantCliTestCase.php
+++ b/tests/Toolkit/TenantCliTestCase.php
@@ -224,12 +224,19 @@ abstract class TenantCliTestCase extends KernelTestCase
      *
      * @param CommandTester $commandTester The command tester
      */
-    protected function assertCommandFailed(CommandTester $commandTester): void
+    public function assertCommandFailed(CommandTester|ExecutionResult $commandTester, string $message = ''): void
     {
+        if ($commandTester instanceof ExecutionResult) {
+            $parentMethod = new \ReflectionMethod(parent::class, __FUNCTION__);
+            $parentMethod->invoke($this, $commandTester, $message);
+
+            return;
+        }
+
         $this->assertNotSame(
             Command::SUCCESS,
             $commandTester->getStatusCode(),
-            'Command should have failed'
+            $message ?: 'Command should have failed'
         );
     }
 

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zhortein\MultiTenantBundle\Tests\DependencyInjection;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Dumper\YamlReferenceDumper;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+use Zhortein\MultiTenantBundle\DependencyInjection\Configuration;
+
+/**
+ * @covers \Zhortein\MultiTenantBundle\DependencyInjection\Configuration
+ */
+final class ConfigurationTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function supportedResolvers(): iterable
+    {
+        foreach (['path', 'subdomain', 'header', 'query', 'domain', 'hybrid', 'dns_txt', 'chain', 'custom'] as $resolver) {
+            yield $resolver => [$resolver];
+        }
+    }
+
+    #[DataProvider('supportedResolvers')]
+    public function testCanonicalResolverIsAcceptedAndNormalized(string $resolver): void
+    {
+        $processed = (new Processor())->processConfiguration(new Configuration(), [['resolver' => $resolver]]);
+
+        self::assertSame($resolver, $processed['resolver']);
+    }
+
+    public function testChainAcceptsEveryBuiltInResolver(): void
+    {
+        $order = ['path', 'subdomain', 'header', 'query', 'domain', 'hybrid', 'dns_txt'];
+        $processed = (new Processor())->processConfiguration(new Configuration(), [[
+            'resolver' => 'chain',
+            'resolver_chain' => ['order' => $order],
+        ]]);
+
+        self::assertSame($order, $processed['resolver_chain']['order']);
+    }
+
+    public function testChainRejectsUnknownResolverInsteadOfSilentlySkippingIt(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The value "jwt" is not allowed');
+
+        (new Processor())->processConfiguration(new Configuration(), [[
+            'resolver' => 'chain',
+            'resolver_chain' => ['order' => ['jwt', 'path']],
+        ]]);
+    }
+
+    public function testResolverTypeStructureIsRejectedWithMigrationInstruction(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Use "resolver: path" instead of the unsupported "resolver.type" structure.');
+
+        (new Processor())->processConfiguration(new Configuration(), [['resolver' => ['type' => 'path']]]);
+    }
+
+    public function testResolutionStrategyStructureIsRejectedWithMigrationInstruction(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Use the scalar "resolver: path" syntax instead.');
+
+        (new Processor())->processConfiguration(new Configuration(), [['resolution' => ['strategy' => 'path']]]);
+    }
+
+    public function testUnknownResolverIsRejectedAndListsSupportedValues(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Permissible values: "path", "subdomain", "header", "query", "domain", "hybrid", "dns_txt", "chain", "custom".');
+
+        (new Processor())->processConfiguration(new Configuration(), [['resolver' => 'automatic']]);
+    }
+
+    public function testReferenceUsesCanonicalResolverSyntax(): void
+    {
+        $reference = (new YamlReferenceDumper())->dump(new Configuration());
+
+        self::assertStringContainsString('resolver:             path', $reference);
+        self::assertStringNotContainsString('resolution:', $reference);
+        self::assertStringNotContainsString("resolver:\n        type:", $reference);
+    }
+}


### PR DESCRIPTION
Refs #9

## Problem

The effective configuration tree has always accepted a scalar `resolver`, but historical documentation also showed non-functional `resolver.type` and `resolution.strategy` structures. The resolver chain documentation additionally claimed that tagged custom resolvers could be inserted even though the bundle has no tag collection mechanism. The compatibility matrix also lacked the required Symfony 8.1/PHP 8.5 combination.

## Solution and architecture

- Keep scalar `resolver` as the only canonical syntax and cover all nine supported values.
- Reject both historical nested structures with actionable configuration errors; no aliases or deprecations are introduced because these structures never worked.
- Restrict `resolver_chain.order` to the seven built-in chain resolvers so unknown names cannot be silently skipped.
- Document the effective custom-resolver contract: implement and alias `TenantResolverInterface`.
- Correct every invalid resolver example in the bundle documentation and audit report.
- Add required Symfony 8.1/PHP 8.5 compatibility and external consumer jobs while retaining Symfony 7.4 LTS and Symfony 8.0 lower-bound coverage.
- Add Symfony YAML as a development-only dependency so the generated configuration reference is tested directly.

## Compatibility

The runtime constraints already use `^8.0`, which permits Symfony 8.1 without modification. Symfony 8.0 remains tested because it is the lower bound of that constraint despite the end of its normal support window. Symfony 7.4 LTS coverage is unchanged. The rejected nested resolver forms and tagged chain extensions were documentation errors and never effective public APIs.

## Tests

- `make composer-validate`
- `composer audit --no-interaction --abandoned=report`
- `make phpstan` (level max)
- `make csfixer-check`
- `make test` (425 tests, 1,058 assertions; 76 environment-dependent skips and 263 notices)
- `make test-with-postgres` (10 tests, 30 assertions)
- Configuration tests for nine top-level resolver values, all seven chain values, invalid nested structures, unknown values, and the YAML reference
- Local Symfony 8.1.2/PHP 8.5 container compilation for both database strategies; the clean external installation is enforced by CI

## Migration impact

Applications already using the effective scalar syntax require no changes. Anyone copying an invalid historical example receives an explicit instruction to use `resolver: path`. Custom resolvers must be aliased to `TenantResolverInterface`; custom names are not accepted in the built-in chain.

The demo documentation correction and Symfony 8.1 update will follow in a separate downstream PR after this bundle PR is merged, so issue #9 remains open until that validation is complete.