### PR TITLE
Register optional integration class aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0-RC3] - 2026-04-05
 
 ### Fixed
+- Added class aliases for optional Mailer and Messenger services so real consumer containers can autowire their concrete dependencies.
 - Kept the tenant CLI test helper compatible with Symfony 8.1's public command assertion while preserving existing CommandTester calls.
 - Corrected historically invalid `resolver.type` and `resolution.strategy` documentation examples to the only supported scalar `resolver` syntax; invalid nested structures now fail with actionable errors.
 - Declared the PSR Simple Cache 3 requirement used by the optional typed PSR-16 decorator and updated Console tests for Symfony 8.

--- a/src/DependencyInjection/ZhorteinMultiTenantExtension.php
+++ b/src/DependencyInjection/ZhorteinMultiTenantExtension.php
@@ -523,6 +523,7 @@ final class ZhorteinMultiTenantExtension extends Extension
         $container->register('zhortein_multi_tenant.mailer.configurator', TenantMailerConfigurator::class)
             ->setAutowired(true)
             ->setAutoconfigured(true);
+        $container->setAlias(TenantMailerConfigurator::class, 'zhortein_multi_tenant.mailer.configurator');
 
         $container->register('zhortein_multi_tenant.mailer.transport_factory', TenantMailerTransportFactory::class)
             ->setAutowired(true)
@@ -532,6 +533,7 @@ final class ZhorteinMultiTenantExtension extends Extension
         $container->register('zhortein_multi_tenant.mailer.tenant_aware', TenantAwareMailer::class)
             ->setAutowired(true)
             ->setAutoconfigured(true);
+        $container->setAlias(TenantAwareMailer::class, 'zhortein_multi_tenant.mailer.tenant_aware');
     }
 
     /**
@@ -549,6 +551,7 @@ final class ZhorteinMultiTenantExtension extends Extension
         $container->register('zhortein_multi_tenant.messenger.configurator', TenantMessengerConfigurator::class)
             ->setAutowired(true)
             ->setAutoconfigured(true);
+        $container->setAlias(TenantMessengerConfigurator::class, 'zhortein_multi_tenant.messenger.configurator');
 
         $container->register('zhortein_multi_tenant.messenger.transport_factory', TenantMessengerTransportFactory::class)
             ->setAutowired(true)
@@ -556,6 +559,8 @@ final class ZhorteinMultiTenantExtension extends Extension
             ->addTag('messenger.transport_factory');
 
         // Register transport resolver middleware
+        $container->setAlias(TenantMessengerTransportFactory::class, 'zhortein_multi_tenant.messenger.transport_factory');
+
         $container->register('zhortein_multi_tenant.messenger.transport_resolver', TenantMessengerTransportResolver::class)
             ->setAutowired(true)
             ->setAutoconfigured(true)
@@ -563,6 +568,7 @@ final class ZhorteinMultiTenantExtension extends Extension
             ->setArgument('$defaultTransport', '%zhortein_multi_tenant.messenger.default_transport%')
             ->setArgument('$addTenantHeaders', '%zhortein_multi_tenant.messenger.add_tenant_headers%')
             ->addTag('messenger.middleware', ['priority' => 100]);
+        $container->setAlias(TenantMessengerTransportResolver::class, 'zhortein_multi_tenant.messenger.transport_resolver');
     }
 
     /**

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -9,7 +9,14 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Dumper\YamlReferenceDumper;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Zhortein\MultiTenantBundle\DependencyInjection\Configuration;
+use Zhortein\MultiTenantBundle\DependencyInjection\ZhorteinMultiTenantExtension;
+use Zhortein\MultiTenantBundle\Mailer\TenantAwareMailer;
+use Zhortein\MultiTenantBundle\Mailer\TenantMailerConfigurator;
+use Zhortein\MultiTenantBundle\Messenger\TenantMessengerConfigurator;
+use Zhortein\MultiTenantBundle\Messenger\TenantMessengerTransportFactory;
+use Zhortein\MultiTenantBundle\Messenger\TenantMessengerTransportResolver;
 
 /**
  * @covers \Zhortein\MultiTenantBundle\DependencyInjection\Configuration
@@ -78,6 +85,21 @@ final class ConfigurationTest extends TestCase
         $this->expectExceptionMessage('Permissible values: "path", "subdomain", "header", "query", "domain", "hybrid", "dns_txt", "chain", "custom".');
 
         (new Processor())->processConfiguration(new Configuration(), [['resolver' => 'automatic']]);
+    }
+
+    public function testOptionalIntegrationClassAliasesAreRegistered(): void
+    {
+        $container = new ContainerBuilder();
+        (new ZhorteinMultiTenantExtension())->load([[
+            'mailer' => ['enabled' => true],
+            'messenger' => ['enabled' => true],
+        ]], $container);
+
+        self::assertSame('zhortein_multi_tenant.mailer.configurator', (string) $container->getAlias(TenantMailerConfigurator::class));
+        self::assertSame('zhortein_multi_tenant.mailer.tenant_aware', (string) $container->getAlias(TenantAwareMailer::class));
+        self::assertSame('zhortein_multi_tenant.messenger.configurator', (string) $container->getAlias(TenantMessengerConfigurator::class));
+        self::assertSame('zhortein_multi_tenant.messenger.transport_factory', (string) $container->getAlias(TenantMessengerTransportFactory::class));
+        self::assertSame('zhortein_multi_tenant.messenger.transport_resolver', (string) $container->getAlias(TenantMessengerTransportResolver::class));
     }
 
     public function testReferenceUsesCanonicalResolverSyntax(): void


### PR DESCRIPTION
Refs #12

## Problem

A real downstream Symfony application with Mailer enabled could not compile because optional integration services were registered under bundle-specific string IDs while their collaborators autowired concrete class names. Unit tests checked only the string definitions and missed the class aliases.

## Solution

Register explicit class aliases for the Mailer configurator and tenant-aware mailer, plus the Messenger configurator, transport factory, and transport resolver. Add a discovered unit regression test that verifies every alias.

## Architecture and compatibility

The existing service IDs remain canonical and unchanged. The class aliases are additive and make the concrete constructor contracts autowirable; no public service is removed or renamed.

## Tests

- Composer validation
- PHPStan at level max
- PHP-CS-Fixer check
- PHPUnit: 426 tests, 1,063 assertions; 76 environment-dependent skips and 263 notices
- PostgreSQL RLS: 10 tests, 30 assertions

## Migration impact

None. This repairs container compilation for existing optional integrations.