### PR TITLE
Fix tenant Mailer fallback factory wiring

### DIFF
--- a/.github/workflows/test-kit.yml
+++ b/.github/workflows/test-kit.yml
@@ -98,6 +98,7 @@ jobs:
           "symfony/framework-bundle:${{ matrix.symfony }}"
           "symfony/http-foundation:${{ matrix.symfony }}"
           "symfony/http-kernel:${{ matrix.symfony }}"
+          "symfony/mailer:${{ matrix.symfony }}"
           "symfony/messenger:${{ matrix.symfony }}"
 
       - name: Install the bundle as an external dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0-RC3] - 2026-04-05
 
 ### Fixed
-- Wired the tenant Mailer factory to a non-recursive aggregate of Symfony transport factories so consumer containers compile with Mailer enabled.
+- Wired the tenant Mailer factory to a non-recursive aggregate of Symfony transport factories and registered its settings repository so consumer containers compile with Mailer enabled.
 - Added class aliases for optional Mailer and Messenger services so real consumer containers can autowire their concrete dependencies.
 - Kept the tenant CLI test helper compatible with Symfony 8.1's public command assertion while preserving existing CommandTester calls.
 - Corrected historically invalid `resolver.type` and `resolution.strategy` documentation examples to the only supported scalar `resolver` syntax; invalid nested structures now fail with actionable errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0-RC3] - 2026-04-05
 
 ### Fixed
+- Wired the tenant Mailer factory to a non-recursive aggregate of Symfony transport factories so consumer containers compile with Mailer enabled.
 - Added class aliases for optional Mailer and Messenger services so real consumer containers can autowire their concrete dependencies.
 - Kept the tenant CLI test helper compatible with Symfony 8.1's public command assertion while preserving existing CommandTester calls.
 - Corrected historically invalid `resolver.type` and `resolution.strategy` documentation examples to the only supported scalar `resolver` syntax; invalid nested structures now fail with actionable errors.

--- a/src/DependencyInjection/ZhorteinMultiTenantExtension.php
+++ b/src/DependencyInjection/ZhorteinMultiTenantExtension.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Zhortein\MultiTenantBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Mailer\Transport as MailerTransport;
 use Zhortein\MultiTenantBundle\Command\ClearTenantSettingsCacheCommand;
 use Zhortein\MultiTenantBundle\Command\CreateTenantCommand;
 use Zhortein\MultiTenantBundle\Command\CreateTenantSchemaCommand;
@@ -525,9 +527,16 @@ final class ZhorteinMultiTenantExtension extends Extension
             ->setAutoconfigured(true);
         $container->setAlias(TenantMailerConfigurator::class, 'zhortein_multi_tenant.mailer.configurator');
 
+        $container->register('zhortein_multi_tenant.mailer.fallback_transport_factory', MailerTransport::class)
+            ->setArgument(0, new TaggedIteratorArgument(
+                'mailer.transport_factory',
+                exclude: ['zhortein_multi_tenant.mailer.transport_factory'],
+            ));
+
         $container->register('zhortein_multi_tenant.mailer.transport_factory', TenantMailerTransportFactory::class)
             ->setAutowired(true)
             ->setAutoconfigured(true)
+            ->setArgument(1, new Reference('zhortein_multi_tenant.mailer.fallback_transport_factory'))
             ->addTag('mailer.transport_factory');
 
         $container->register('zhortein_multi_tenant.mailer.tenant_aware', TenantAwareMailer::class)

--- a/src/DependencyInjection/ZhorteinMultiTenantExtension.php
+++ b/src/DependencyInjection/ZhorteinMultiTenantExtension.php
@@ -48,6 +48,7 @@ use Zhortein\MultiTenantBundle\Observability\Metrics\MetricsAdapterInterface;
 use Zhortein\MultiTenantBundle\Observability\Metrics\NullMetricsAdapter;
 use Zhortein\MultiTenantBundle\Registry\DoctrineTenantRegistry;
 use Zhortein\MultiTenantBundle\Registry\TenantRegistryInterface;
+use Zhortein\MultiTenantBundle\Repository\TenantSettingRepository;
 use Zhortein\MultiTenantBundle\Resolver\ChainTenantResolver;
 use Zhortein\MultiTenantBundle\Resolver\DnsTxtTenantResolver;
 use Zhortein\MultiTenantBundle\Resolver\DomainBasedTenantResolver;
@@ -178,6 +179,10 @@ final class ZhorteinMultiTenantExtension extends Extension
         $container->setAlias(TenantRegistryInterface::class, DoctrineTenantRegistry::class);
 
         // Register tenant settings manager
+        $container->register(TenantSettingRepository::class)
+            ->setAutowired(true)
+            ->setAutoconfigured(true);
+
         $container->register(TenantSettingsManager::class)
             ->setAutowired(true)
             ->setAutoconfigured(true)

--- a/tests/ConsumerApp/README.md
+++ b/tests/ConsumerApp/README.md
@@ -2,7 +2,7 @@
 
 This fixture is a standalone Symfony application used only for compatibility validation. Its Composer path repository disables symlinks, so the bundle is copied under the fixture vendor directory and behaves like an external dependency.
 
-GitHub Actions selects Symfony 7.4, 8.0, or 8.1, installs the fixture dependencies, and boots separate `shared_db` and `multi_db` kernels. Both configurations must compile without Mailer, Twig, Monolog, or PSR-16.
+GitHub Actions selects Symfony 7.4, 8.0, or 8.1, installs the fixture dependencies, and boots separate `shared_db` and `multi_db` kernels. Both configurations must compile with the optional Mailer integration enabled and without Twig, Monolog, or PSR-16.
 
 From the repository root, reproduce the PHP 8.3 and Symfony 7.4 scenario with:
 

--- a/tests/ConsumerApp/composer.json
+++ b/tests/ConsumerApp/composer.json
@@ -23,6 +23,7 @@
     "symfony/framework-bundle": "~7.4.0",
     "symfony/http-foundation": "~7.4.0",
     "symfony/http-kernel": "~7.4.0",
+    "symfony/mailer": "~7.4.0",
     "symfony/messenger": "~7.4.0",
     "zhortein/multi-tenant-bundle": "@dev"
   },

--- a/tests/ConsumerApp/src/Kernel.php
+++ b/tests/ConsumerApp/src/Kernel.php
@@ -37,6 +37,7 @@ final class Kernel extends BaseKernel
         $container->loadFromExtension('framework', [
             'secret' => 'consumer-fixture-secret',
             'test' => true,
+            'mailer' => ['dsn' => 'null://null'],
         ]);
         $container->loadFromExtension('doctrine', [
             'dbal' => ['url' => 'sqlite:///%kernel.cache_dir%/consumer.db'],
@@ -64,7 +65,7 @@ final class Kernel extends BaseKernel
                 'logger' => ['enabled' => false],
             ],
             'fixtures' => ['enabled' => false],
-            'mailer' => ['enabled' => false],
+            'mailer' => ['enabled' => true],
             'storage' => ['enabled' => false],
         ]);
     }

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -9,7 +9,10 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Dumper\YamlReferenceDumper;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Mailer\Transport as MailerTransport;
 use Zhortein\MultiTenantBundle\DependencyInjection\Configuration;
 use Zhortein\MultiTenantBundle\DependencyInjection\ZhorteinMultiTenantExtension;
 use Zhortein\MultiTenantBundle\Mailer\TenantAwareMailer;
@@ -100,6 +103,29 @@ final class ConfigurationTest extends TestCase
         self::assertSame('zhortein_multi_tenant.messenger.configurator', (string) $container->getAlias(TenantMessengerConfigurator::class));
         self::assertSame('zhortein_multi_tenant.messenger.transport_factory', (string) $container->getAlias(TenantMessengerTransportFactory::class));
         self::assertSame('zhortein_multi_tenant.messenger.transport_resolver', (string) $container->getAlias(TenantMessengerTransportResolver::class));
+    }
+
+    public function testMailerFactoryUsesANonRecursiveFallbackAggregate(): void
+    {
+        $container = new ContainerBuilder();
+        (new ZhorteinMultiTenantExtension())->load([[
+            'mailer' => ['enabled' => true],
+        ]], $container);
+
+        $fallback = $container->getDefinition('zhortein_multi_tenant.mailer.fallback_transport_factory');
+        self::assertSame(MailerTransport::class, $fallback->getClass());
+
+        $factories = $fallback->getArgument(0);
+        self::assertInstanceOf(TaggedIteratorArgument::class, $factories);
+        self::assertSame(
+            ['zhortein_multi_tenant.mailer.transport_factory'],
+            $factories->getExclude(),
+        );
+
+        $factory = $container->getDefinition('zhortein_multi_tenant.mailer.transport_factory');
+        $fallbackReference = $factory->getArgument(1);
+        self::assertInstanceOf(Reference::class, $fallbackReference);
+        self::assertSame('zhortein_multi_tenant.mailer.fallback_transport_factory', (string) $fallbackReference);
     }
 
     public function testReferenceUsesCanonicalResolverSyntax(): void

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -20,6 +20,7 @@ use Zhortein\MultiTenantBundle\Mailer\TenantMailerConfigurator;
 use Zhortein\MultiTenantBundle\Messenger\TenantMessengerConfigurator;
 use Zhortein\MultiTenantBundle\Messenger\TenantMessengerTransportFactory;
 use Zhortein\MultiTenantBundle\Messenger\TenantMessengerTransportResolver;
+use Zhortein\MultiTenantBundle\Repository\TenantSettingRepository;
 
 /**
  * @covers \Zhortein\MultiTenantBundle\DependencyInjection\Configuration
@@ -111,6 +112,8 @@ final class ConfigurationTest extends TestCase
         (new ZhorteinMultiTenantExtension())->load([[
             'mailer' => ['enabled' => true],
         ]], $container);
+
+        self::assertTrue($container->hasDefinition(TenantSettingRepository::class));
 
         $fallback = $container->getDefinition('zhortein_multi_tenant.mailer.fallback_transport_factory');
         self::assertSame(MailerTransport::class, $fallback->getClass());


### PR DESCRIPTION
## Problem

A real Symfony consumer with the bundle Mailer integration enabled could not compile its container. TenantMailerTransportFactory requested TransportFactoryInterface, while Symfony registers multiple implementations and therefore cannot autowire a unique fallback. The earlier class-alias correction exposed this second integration defect.

## Solution

Register a dedicated Symfony Transport aggregate for fallback transports, explicitly excluding the bundle tenant transport factory, and inject that aggregate into TenantMailerTransportFactory. This removes both the autowiring ambiguity and recursive factory selection without changing the public constructor or configuration API.

## Regression coverage

- Assert the fallback aggregate and explicit injection in the dependency-injection unit suite.
- Enable the optional Mailer integration in the external consumer fixture.
- Compile both shared_db and multi_db consumers on Symfony 7.4, 8.0, and 8.1, including PHP 8.5 for Symfony 8.1.

## Validation

- Composer validation: passed
- Composer security audit: no advisories
- PHPStan at the repository maximum level: passed
- PHP-CS-Fixer check: passed (178 files)
- PHPUnit: passed (427 tests, 1,068 assertions)
- Effective PostgreSQL RLS suite: passed (10 tests, 30 assertions)

## Compatibility and migration

The correction is additive container wiring. It does not change the public API, configuration syntax, supported versions, or require migration.

Refs #12