### PR TITLE
Fix tenant Messenger factory wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0-RC3] - 2026-04-05
 
 ### Fixed
+- Injected the non-recursive Symfony transport factory iterator required by the tenant Messenger integration.
 - Wired the tenant Mailer factory to a non-recursive aggregate of Symfony transport factories and registered its settings repository so consumer containers compile with Mailer enabled.
 - Added class aliases for optional Mailer and Messenger services so real consumer containers can autowire their concrete dependencies.
 - Kept the tenant CLI test helper compatible with Symfony 8.1's public command assertion while preserving existing CommandTester calls.

--- a/src/DependencyInjection/ZhorteinMultiTenantExtension.php
+++ b/src/DependencyInjection/ZhorteinMultiTenantExtension.php
@@ -570,6 +570,10 @@ final class ZhorteinMultiTenantExtension extends Extension
         $container->register('zhortein_multi_tenant.messenger.transport_factory', TenantMessengerTransportFactory::class)
             ->setAutowired(true)
             ->setAutoconfigured(true)
+            ->setArgument(1, new TaggedIteratorArgument(
+                'messenger.transport_factory',
+                exclude: ['zhortein_multi_tenant.messenger.transport_factory'],
+            ))
             ->addTag('messenger.transport_factory');
 
         // Register transport resolver middleware

--- a/src/DependencyInjection/ZhorteinMultiTenantExtension.php
+++ b/src/DependencyInjection/ZhorteinMultiTenantExtension.php
@@ -570,7 +570,7 @@ final class ZhorteinMultiTenantExtension extends Extension
         $container->register('zhortein_multi_tenant.messenger.transport_factory', TenantMessengerTransportFactory::class)
             ->setAutowired(true)
             ->setAutoconfigured(true)
-            ->setArgument(1, new TaggedIteratorArgument(
+            ->setArgument('$factories', new TaggedIteratorArgument(
                 'messenger.transport_factory',
                 exclude: ['zhortein_multi_tenant.messenger.transport_factory'],
             ))

--- a/tests/ConsumerApp/README.md
+++ b/tests/ConsumerApp/README.md
@@ -2,7 +2,7 @@
 
 This fixture is a standalone Symfony application used only for compatibility validation. Its Composer path repository disables symlinks, so the bundle is copied under the fixture vendor directory and behaves like an external dependency.
 
-GitHub Actions selects Symfony 7.4, 8.0, or 8.1, installs the fixture dependencies, and boots separate `shared_db` and `multi_db` kernels. Both configurations must compile with the optional Mailer integration enabled and without Twig, Monolog, or PSR-16.
+GitHub Actions selects Symfony 7.4, 8.0, or 8.1, installs the fixture dependencies, and boots separate `shared_db` and `multi_db` kernels. Both configurations must compile with the optional Mailer and Messenger integrations enabled and without Twig, Monolog, or PSR-16.
 
 From the repository root, reproduce the PHP 8.3 and Symfony 7.4 scenario with:
 

--- a/tests/ConsumerApp/src/Kernel.php
+++ b/tests/ConsumerApp/src/Kernel.php
@@ -38,6 +38,10 @@ final class Kernel extends BaseKernel
             'secret' => 'consumer-fixture-secret',
             'test' => true,
             'mailer' => ['dsn' => 'null://null'],
+            'messenger' => [
+                'default_bus' => 'messenger.bus.default',
+                'transports' => ['async' => 'sync://'],
+            ],
         ]);
         $container->loadFromExtension('doctrine', [
             'dbal' => ['url' => 'sqlite:///%kernel.cache_dir%/consumer.db'],

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -105,7 +105,7 @@ final class ConfigurationTest extends TestCase
         self::assertSame('zhortein_multi_tenant.messenger.transport_factory', (string) $container->getAlias(TenantMessengerTransportFactory::class));
 
         $messengerFactory = $container->getDefinition('zhortein_multi_tenant.messenger.transport_factory');
-        $messengerFactories = $messengerFactory->getArgument(1);
+        $messengerFactories = $messengerFactory->getArgument('$factories');
         self::assertInstanceOf(TaggedIteratorArgument::class, $messengerFactories);
         self::assertSame(
             ['zhortein_multi_tenant.messenger.transport_factory'],

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -103,6 +103,14 @@ final class ConfigurationTest extends TestCase
         self::assertSame('zhortein_multi_tenant.mailer.tenant_aware', (string) $container->getAlias(TenantAwareMailer::class));
         self::assertSame('zhortein_multi_tenant.messenger.configurator', (string) $container->getAlias(TenantMessengerConfigurator::class));
         self::assertSame('zhortein_multi_tenant.messenger.transport_factory', (string) $container->getAlias(TenantMessengerTransportFactory::class));
+
+        $messengerFactory = $container->getDefinition('zhortein_multi_tenant.messenger.transport_factory');
+        $messengerFactories = $messengerFactory->getArgument(1);
+        self::assertInstanceOf(TaggedIteratorArgument::class, $messengerFactories);
+        self::assertSame(
+            ['zhortein_multi_tenant.messenger.transport_factory'],
+            $messengerFactories->getExclude(),
+        );
         self::assertSame('zhortein_multi_tenant.messenger.transport_resolver', (string) $container->getAlias(TenantMessengerTransportResolver::class));
     }
 


### PR DESCRIPTION
## Problem

The real demo consumer could not compile after the Mailer wiring repairs because the PHP extension registered TenantMessengerTransportFactory without providing its iterable of Symfony transport factories. An obsolete YAML service declaration contained that argument, but it is not the effective registration path.

## Solution

Inject a tagged iterator of Messenger transport factories into the effective extension registration and explicitly exclude the tenant factory itself. This removes the unresolved iterable and prevents recursive factory selection without changing the public constructor or configuration API.

## Regression coverage

- Assert the tagged iterator and self-exclusion in the dependency-injection unit suite.
- Enable a real Messenger bus and sync transport in the external consumer fixture.
- Compile Mailer and Messenger together for shared_db and multi_db on Symfony 7.4, 8.0, and 8.1.

## Validation

- Composer validation: passed
- Composer security audit: no advisories
- PHPStan at maximum level: passed
- PHP-CS-Fixer check: passed
- PHPUnit: passed (427 tests, 1,071 assertions)
- Effective PostgreSQL RLS: passed (10 tests, 30 assertions)

## Compatibility and migration

This is additive container wiring with no public API, configuration, or migration impact.

Refs #12