### PR TITLE
Fix consumer Mailer and Doctrine integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0-RC3] - 2026-04-05
 
 ### Fixed
+- Registered a contract-correct aggregate Mailer transport factory and mapped `TenantInterface` to the configured tenant entity so real consumer containers and Doctrine metadata validate successfully.
 - Injected the non-recursive Symfony transport factory iterator required by the tenant Messenger integration.
 - Wired the tenant Mailer factory to a non-recursive aggregate of Symfony transport factories and registered its settings repository so consumer containers compile with Mailer enabled.
 - Added class aliases for optional Mailer and Messenger services so real consumer containers can autowire their concrete dependencies.

--- a/src/DependencyInjection/ZhorteinMultiTenantExtension.php
+++ b/src/DependencyInjection/ZhorteinMultiTenantExtension.php
@@ -8,9 +8,9 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\Mailer\Transport as MailerTransport;
 use Zhortein\MultiTenantBundle\Command\ClearTenantSettingsCacheCommand;
 use Zhortein\MultiTenantBundle\Command\CreateTenantCommand;
 use Zhortein\MultiTenantBundle\Command\CreateTenantSchemaCommand;
@@ -30,12 +30,14 @@ use Zhortein\MultiTenantBundle\Doctrine\DefaultConnectionResolver;
 use Zhortein\MultiTenantBundle\Doctrine\EventAwareConnectionResolver;
 use Zhortein\MultiTenantBundle\Doctrine\TenantConnectionResolverInterface;
 use Zhortein\MultiTenantBundle\Doctrine\TenantEntityManagerFactory;
+use Zhortein\MultiTenantBundle\Entity\TenantInterface;
 use Zhortein\MultiTenantBundle\EventListener\TenantDoctrineFilterListener;
 use Zhortein\MultiTenantBundle\EventListener\TenantEntityListener;
 use Zhortein\MultiTenantBundle\EventListener\TenantRequestListener;
 use Zhortein\MultiTenantBundle\EventListener\TenantResolutionExceptionListener;
 use Zhortein\MultiTenantBundle\Mailer\TenantAwareMailer;
 use Zhortein\MultiTenantBundle\Mailer\TenantMailerConfigurator;
+use Zhortein\MultiTenantBundle\Mailer\TenantMailerFallbackTransportFactory;
 use Zhortein\MultiTenantBundle\Mailer\TenantMailerTransportFactory;
 use Zhortein\MultiTenantBundle\Manager\TenantSettingsManager;
 use Zhortein\MultiTenantBundle\Manager\TenantSettingsManagerInterface;
@@ -68,8 +70,28 @@ use Zhortein\MultiTenantBundle\Storage\TenantFileStorageInterface;
  * This class handles the configuration and registration of all bundle services,
  * including tenant resolvers, context managers, event listeners, and commands.
  */
-final class ZhorteinMultiTenantExtension extends Extension
+final class ZhorteinMultiTenantExtension extends Extension implements PrependExtensionInterface
 {
+    public function prepend(ContainerBuilder $container): void
+    {
+        if (!$container->hasExtension('doctrine')) {
+            return;
+        }
+
+        $config = $this->processConfiguration(
+            new Configuration(),
+            $container->getExtensionConfig($this->getAlias()),
+        );
+
+        $container->prependExtensionConfig('doctrine', [
+            'orm' => [
+                'resolve_target_entities' => [
+                    TenantInterface::class => $config['tenant_entity'],
+                ],
+            ],
+        ]);
+    }
+
     public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
@@ -532,7 +554,7 @@ final class ZhorteinMultiTenantExtension extends Extension
             ->setAutoconfigured(true);
         $container->setAlias(TenantMailerConfigurator::class, 'zhortein_multi_tenant.mailer.configurator');
 
-        $container->register('zhortein_multi_tenant.mailer.fallback_transport_factory', MailerTransport::class)
+        $container->register('zhortein_multi_tenant.mailer.fallback_transport_factory', TenantMailerFallbackTransportFactory::class)
             ->setArgument(0, new TaggedIteratorArgument(
                 'mailer.transport_factory',
                 exclude: ['zhortein_multi_tenant.mailer.transport_factory'],

--- a/src/Mailer/TenantMailerFallbackTransportFactory.php
+++ b/src/Mailer/TenantMailerFallbackTransportFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zhortein\MultiTenantBundle\Mailer;
+
+use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+
+/**
+ * Selects the first Symfony transport factory supporting a fallback DSN.
+ *
+ * @internal
+ */
+final readonly class TenantMailerFallbackTransportFactory implements TransportFactoryInterface
+{
+    /**
+     * @param iterable<TransportFactoryInterface> $factories
+     */
+    public function __construct(private iterable $factories)
+    {
+    }
+
+    public function create(Dsn $dsn): TransportInterface
+    {
+        foreach ($this->factories as $factory) {
+            if ($factory->supports($dsn)) {
+                return $factory->create($dsn);
+            }
+        }
+
+        throw new UnsupportedSchemeException($dsn);
+    }
+
+    public function supports(Dsn $dsn): bool
+    {
+        foreach ($this->factories as $factory) {
+            if ($factory->supports($dsn)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Zhortein\MultiTenantBundle\Tests\DependencyInjection;
 
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Dumper\YamlReferenceDumper;
@@ -12,11 +13,12 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\Mailer\Transport as MailerTransport;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
 use Zhortein\MultiTenantBundle\DependencyInjection\Configuration;
 use Zhortein\MultiTenantBundle\DependencyInjection\ZhorteinMultiTenantExtension;
 use Zhortein\MultiTenantBundle\Mailer\TenantAwareMailer;
 use Zhortein\MultiTenantBundle\Mailer\TenantMailerConfigurator;
+use Zhortein\MultiTenantBundle\Mailer\TenantMailerFallbackTransportFactory;
 use Zhortein\MultiTenantBundle\Messenger\TenantMessengerConfigurator;
 use Zhortein\MultiTenantBundle\Messenger\TenantMessengerTransportFactory;
 use Zhortein\MultiTenantBundle\Messenger\TenantMessengerTransportResolver;
@@ -124,7 +126,8 @@ final class ConfigurationTest extends TestCase
         self::assertTrue($container->hasDefinition(TenantSettingRepository::class));
 
         $fallback = $container->getDefinition('zhortein_multi_tenant.mailer.fallback_transport_factory');
-        self::assertSame(MailerTransport::class, $fallback->getClass());
+        self::assertSame(TenantMailerFallbackTransportFactory::class, $fallback->getClass());
+        self::assertTrue(is_a($fallback->getClass(), TransportFactoryInterface::class, true));
 
         $factories = $fallback->getArgument(0);
         self::assertInstanceOf(TaggedIteratorArgument::class, $factories);
@@ -137,6 +140,25 @@ final class ConfigurationTest extends TestCase
         $fallbackReference = $factory->getArgument(1);
         self::assertInstanceOf(Reference::class, $fallbackReference);
         self::assertSame('zhortein_multi_tenant.mailer.fallback_transport_factory', (string) $fallbackReference);
+    }
+
+    public function testDoctrineResolvesTenantInterfaceToTheConfiguredEntity(): void
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new DoctrineExtension());
+        $extension = new ZhorteinMultiTenantExtension();
+        $container->registerExtension($extension);
+        $container->loadFromExtension($extension->getAlias(), [
+            'tenant_entity' => "App\Entity\Tenant",
+        ]);
+
+        $extension->prepend($container);
+
+        $doctrineConfig = $container->getExtensionConfig('doctrine');
+        self::assertSame(
+            "App\Entity\Tenant",
+            $doctrineConfig[0]['orm']['resolve_target_entities'][\Zhortein\MultiTenantBundle\Entity\TenantInterface::class],
+        );
     }
 
     public function testReferenceUsesCanonicalResolverSyntax(): void

--- a/tests/Unit/Mailer/TenantMailerFallbackTransportFactoryTest.php
+++ b/tests/Unit/Mailer/TenantMailerFallbackTransportFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zhortein\MultiTenantBundle\Tests\Mailer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Zhortein\MultiTenantBundle\Mailer\TenantMailerFallbackTransportFactory;
+
+final class TenantMailerFallbackTransportFactoryTest extends TestCase
+{
+    public function testDelegatesToTheFirstSupportingFactory(): void
+    {
+        $dsn = new Dsn('smtp', 'localhost');
+        $unsupportedFactory = $this->createMock(TransportFactoryInterface::class);
+        $unsupportedFactory->method('supports')->with($dsn)->willReturn(false);
+        $unsupportedFactory->expects(self::never())->method('create');
+
+        $transport = $this->createMock(TransportInterface::class);
+        $supportedFactory = $this->createMock(TransportFactoryInterface::class);
+        $supportedFactory->method('supports')->with($dsn)->willReturn(true);
+        $supportedFactory->expects(self::once())->method('create')->with($dsn)->willReturn($transport);
+
+        $factory = new TenantMailerFallbackTransportFactory([$unsupportedFactory, $supportedFactory]);
+
+        self::assertTrue($factory->supports($dsn));
+        self::assertSame($transport, $factory->create($dsn));
+    }
+
+    public function testRejectsAnUnsupportedScheme(): void
+    {
+        $dsn = new Dsn('unsupported', 'localhost');
+        $delegate = $this->createMock(TransportFactoryInterface::class);
+        $delegate->expects(self::once())->method('supports')->with($dsn)->willReturn(false);
+
+        $factory = new TenantMailerFallbackTransportFactory([$delegate]);
+
+        $this->expectException(UnsupportedSchemeException::class);
+        $factory->create($dsn);
+    }
+}


### PR DESCRIPTION
## Problem

The real demo consumer exposed two integration defects that unit-level container compilation did not detect:

- the Mailer fallback service used the aggregate Transport class even though TenantMailerTransportFactory requires TransportFactoryInterface;
- TenantSetting targets TenantInterface, but Doctrine was not told which configured tenant entity implements that interface.

This caused container linting and Doctrine metadata validation to fail in a real application.

## Solution

- add an internal aggregate Mailer transport factory that delegates to the first supporting Symfony factory and throws an actionable unsupported-scheme exception otherwise;
- register that contract-correct factory as the tenant Mailer fallback;
- prepend Doctrine resolve_target_entities configuration from the existing tenant_entity bundle option;
- add regression tests for service wiring, factory delegation and rejection, and Doctrine mapping;
- document the consumer integration correction in the changelog.

## Architecture and compatibility

The changes preserve the existing public configuration and tenant API. They use existing Symfony and Doctrine extension points and add no production dependency. Optional Mailer behavior remains optional. This is a follow-up discovered while validating the downstream demo and contributes to #12.

## Validation

- Composer validate --strict
- PHPStan level max: no errors
- PHPUnit: 430 tests, 1085 assertions; 76 environment-dependent skips and 264 existing notices in the non-PostgreSQL run
- PostgreSQL 16 RLS: 10 tests, 30 assertions
- PHP-CS-Fixer check: clean
- Composer security audit: no advisories