### PR TITLE
Fix Symfony cache adapter integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0-RC3] - 2026-04-05
 
 ### Fixed
+- Kept tenant-aware Symfony cache decorators compatible with traceable adapters while preserving same-tenant access and cross-tenant namespace isolation.
 - Registered a contract-correct aggregate Mailer transport factory and mapped `TenantInterface` to the configured tenant entity so real consumer containers and Doctrine metadata validate successfully.
 - Injected the non-recursive Symfony transport factory iterator required by the tenant Messenger integration.
 - Wired the tenant Mailer factory to a non-recursive aggregate of Symfony transport factories and registered its settings repository so consumer containers compile with Mailer enabled.

--- a/src/Decorator/TenantAwareCacheAdapterDecorator.php
+++ b/src/Decorator/TenantAwareCacheAdapterDecorator.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zhortein\MultiTenantBundle\Decorator;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\ProxyAdapter;
+use Symfony\Component\Cache\CacheItem;
+use Symfony\Contracts\Cache\CacheInterface;
+use Zhortein\MultiTenantBundle\Context\TenantContextInterface;
+
+/**
+ * Adapts a Symfony cache pool while isolating every operation by tenant namespace.
+ *
+ * @internal
+ */
+final readonly class TenantAwareCacheAdapterDecorator implements AdapterInterface, CacheInterface
+{
+    public function __construct(
+        private CacheItemPoolInterface $decorated,
+        private TenantContextInterface $tenantContext,
+        private bool $enabled = true,
+    ) {
+    }
+
+    /**
+     * @param array<array-key, mixed>|null $metadata
+     */
+    public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
+    {
+        return $this->adapter()->get($key, $callback, $beta, $metadata);
+    }
+
+    public function getItem(mixed $key): CacheItem
+    {
+        return $this->adapter()->getItem($key);
+    }
+
+    public function getItems(array $keys = []): iterable
+    {
+        return $this->adapter()->getItems($keys);
+    }
+
+    public function hasItem(mixed $key): bool
+    {
+        return $this->adapter()->hasItem($key);
+    }
+
+    public function clear(string $prefix = ''): bool
+    {
+        return $this->adapter()->clear($prefix);
+    }
+
+    public function delete(string $key): bool
+    {
+        return $this->adapter()->delete($key);
+    }
+
+    public function deleteItem(mixed $key): bool
+    {
+        return $this->adapter()->deleteItem($key);
+    }
+
+    public function deleteItems(array $keys): bool
+    {
+        return $this->adapter()->deleteItems($keys);
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        return $this->adapter()->save($item);
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return $this->adapter()->saveDeferred($item);
+    }
+
+    public function commit(): bool
+    {
+        return $this->adapter()->commit();
+    }
+
+    private function adapter(): ProxyAdapter
+    {
+        $tenant = $this->tenantContext->getTenant();
+        $namespace = $this->enabled && null !== $tenant
+            ? sprintf('tenant_%s_', $tenant->getId())
+            : '';
+
+        return new ProxyAdapter($this->decorated, $namespace);
+    }
+}

--- a/src/DependencyInjection/ZhorteinMultiTenantExtension.php
+++ b/src/DependencyInjection/ZhorteinMultiTenantExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Zhortein\MultiTenantBundle\DependencyInjection;
 
+use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -23,6 +24,7 @@ use Zhortein\MultiTenantBundle\Command\TenantImpersonateCommand;
 use Zhortein\MultiTenantBundle\Context\TenantContext;
 use Zhortein\MultiTenantBundle\Context\TenantContextInterface;
 use Zhortein\MultiTenantBundle\Database\TenantSessionConfigurator;
+use Zhortein\MultiTenantBundle\Decorator\TenantAwareCacheAdapterDecorator;
 use Zhortein\MultiTenantBundle\Decorator\TenantAwareCacheDecorator;
 use Zhortein\MultiTenantBundle\Decorator\TenantLoggerProcessor;
 use Zhortein\MultiTenantBundle\Decorator\TenantStoragePathHelper;
@@ -702,8 +704,12 @@ final class ZhorteinMultiTenantExtension extends Extension implements PrependExt
         if ($config['decorators']['cache']['enabled']) {
             foreach ($config['decorators']['cache']['services'] as $serviceId) {
                 $serviceIdString = (string) $serviceId;
-                // Register PSR-6 cache decorator
-                $container->register($serviceIdString.'.tenant_aware', TenantAwareCacheDecorator::class)
+                // Symfony cache pools must retain AdapterInterface for debug and traceable wrappers.
+                $decoratorClass = interface_exists(AdapterInterface::class)
+                    ? TenantAwareCacheAdapterDecorator::class
+                    : TenantAwareCacheDecorator::class;
+
+                $container->register($serviceIdString.'.tenant_aware', $decoratorClass)
                     ->setDecoratedService($serviceIdString)
                     ->setAutowired(true)
                     ->setArgument('$enabled', '%zhortein_multi_tenant.decorators.cache.enabled%');

--- a/tests/Unit/Decorator/TenantAwareCacheAdapterDecoratorTest.php
+++ b/tests/Unit/Decorator/TenantAwareCacheAdapterDecoratorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zhortein\MultiTenantBundle\Tests\Unit\Decorator;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\TraceableAdapter;
+use Zhortein\MultiTenantBundle\Context\TenantContext;
+use Zhortein\MultiTenantBundle\Decorator\TenantAwareCacheAdapterDecorator;
+use Zhortein\MultiTenantBundle\Tests\Fixtures\Entity\TestTenant;
+
+final class TenantAwareCacheAdapterDecoratorTest extends TestCase
+{
+    public function testItRetainsTheSymfonyAdapterContractAndIsolatesTenantNamespaces(): void
+    {
+        $context = new TenantContext();
+        $decorator = new TenantAwareCacheAdapterDecorator(new ArrayAdapter(), $context);
+
+        self::assertInstanceOf(AdapterInterface::class, $decorator);
+        self::assertInstanceOf(TraceableAdapter::class, new TraceableAdapter($decorator));
+
+        $context->setTenant((new TestTenant())->setId(1));
+        $tenantOneItem = $decorator->getItem('shared-key')->set('tenant-one');
+        self::assertTrue($decorator->save($tenantOneItem));
+        self::assertSame('tenant-one', $decorator->getItem('shared-key')->get());
+
+        $context->setTenant((new TestTenant())->setId(2));
+        self::assertFalse($decorator->getItem('shared-key')->isHit());
+        $tenantTwoItem = $decorator->getItem('shared-key')->set('tenant-two');
+        self::assertTrue($decorator->save($tenantTwoItem));
+        self::assertSame('tenant-two', $decorator->getItem('shared-key')->get());
+        self::assertTrue($decorator->clear());
+        self::assertFalse($decorator->getItem('shared-key')->isHit());
+
+        $context->setTenant((new TestTenant())->setId(1));
+        self::assertSame('tenant-one', $decorator->getItem('shared-key')->get());
+    }
+}


### PR DESCRIPTION
## Problem

The real Symfony 7.4 demo consumer failed container linting in debug mode. The bundle decorated cache.app with a PSR-6-only service, while the Symfony TraceableAdapter constructor requires AdapterInterface. The earlier bundle tests did not compile this debug wrapper and therefore missed the contract mismatch.

## Solution

- add an internal tenant-aware Symfony cache adapter based on ProxyAdapter;
- retain AdapterInterface and CacheInterface for Symfony wrappers while preserving the existing PSR-6 fallback when Symfony Cache is unavailable;
- isolate every cache operation by tenant namespace;
- prove same-tenant reads, denied cross-tenant visibility, tenant-scoped clearing, and TraceableAdapter compatibility;
- document the correction in the changelog.

## Architecture and compatibility

The public cache decorator and configuration remain unchanged. The new adapter is selected only when Symfony Cache is installed and adds no production dependency. Generic PSR-6 consumers keep the existing decorator. This correction contributes to the consumer integration work tracked by #12.

## Validation

- real multi-tenant-demo Symfony 7.4 debug container lint: pass with this checkout mounted as the external bundle
- Composer validate --strict
- PHPStan level max: no errors
- PHPUnit: 431 tests, 1095 assertions; 76 environment-dependent skips and 264 existing notices in the non-PostgreSQL run
- PostgreSQL 16 RLS: 10 tests, 30 assertions
- PHP-CS-Fixer check: clean
- Composer security audit: no advisories