### PR TITLE
Enforce the PostgreSQL RLS threat model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0-RC3] - 2026-04-05
 
 ### Fixed
+- Enforced PostgreSQL RLS for table owners with explicit read/write predicates and expanded real-database coverage for UPDATE, DELETE, rollback cleanup, and connection reuse.
 - Kept tenant-aware Symfony cache decorators compatible with traceable adapters while preserving same-tenant access and cross-tenant namespace isolation.
 - Registered a contract-correct aggregate Mailer transport factory and mapped `TenantInterface` to the configured tenant entity so real consumer containers and Doctrine metadata validate successfully.
 - Injected the non-recursive Symfony transport factory iterator required by the tenant Messenger integration.

--- a/docs/audit-2026-07.md
+++ b/docs/audit-2026-07.md
@@ -112,3 +112,9 @@ The initial quality report contained a false positive: `make test-with-postgres`
 The repaired harness now builds a PHP 8.3 test image with `pdo_pgsql`, waits for PostgreSQL 16 health, and makes database availability mandatory. Schema setup uses the administrative role, while all security assertions use a separate non-superuser role. Six tests with 24 assertions verify policy metadata, forced RLS, allowed same-tenant reads and writes, denied cross-tenant reads and writes, tenant switching, raw SQL isolation without the Doctrine filter, and fail-closed behavior when the tenant session is cleared.
 
 The real database tests also exposed an implementation defect: `TenantSessionConfigurator` used transaction-local `set_config(..., true)` outside guaranteed transactions. Tenant state could disappear before protected queries, and a request without a tenant did not clear prior session state. The configurator now uses session-scoped values and explicitly clears the setting when context is absent and after Messenger handling.
+
+## Post-audit RLS threat-model completion
+
+Issue #14 extended the effective PostgreSQL suite from 10 tests and 30 assertions to 14 tests and 54 assertions. The new adversarial coverage proves allowed same-tenant and hidden cross-tenant UPDATE and DELETE behavior, rollback cleanup before connection reuse, and fail-closed state on a newly opened application connection. The policy generator now emits both `ENABLE ROW LEVEL SECURITY` and `FORCE ROW LEVEL SECURITY`, with an explicit `FOR ALL` policy containing matching `USING` and `WITH CHECK` predicates.
+
+The security guide now distinguishes ORM filter coverage from DQL, QueryBuilder, DBAL, and native SQL boundaries; defines restricted application-role requirements; and documents transaction, worker, CLI, persistent-connection, and pool-reset responsibilities. Superusers and roles with `BYPASSRLS` remain intentionally outside the RLS protection boundary.

--- a/docs/rls-security.md
+++ b/docs/rls-security.md
@@ -8,6 +8,32 @@ The multi-tenant bundle supports PostgreSQL Row-Level Security (RLS) as an addit
 
 Row-Level Security provides database-level tenant isolation by creating policies that automatically filter rows based on the current tenant context. This works alongside Doctrine filters to provide multiple layers of protection.
 
+## Threat model and query boundaries
+
+RLS protects tenant-owned rows when application code reaches PostgreSQL through Doctrine ORM, DQL, QueryBuilder, DBAL, or native SQL. The Doctrine tenant filter protects ORM-generated reads only: it does not cover DBAL or native SQL and must never be described as sufficient for those paths. RLS is the database-enforced boundary for bypass scenarios.
+
+The supported policy is fail-closed. With no active tenant, `app.tenant_id` is cleared to an empty value and tenant-owned SELECT, INSERT, UPDATE, and DELETE operations expose or affect no rows. Same-tenant operations are allowed. Cross-tenant SELECT rows are hidden, cross-tenant UPDATE and DELETE affect zero rows, and cross-tenant INSERT is rejected by `WITH CHECK`.
+
+RLS does not protect:
+
+- tables that are not tenant-aware or do not have a synchronized policy;
+- privileged maintenance connections that deliberately use a superuser or a role with `BYPASSRLS`;
+- table owners unless `FORCE ROW LEVEL SECURITY` is enabled;
+- data copied outside PostgreSQL before the policy is evaluated.
+
+Application authorization remains required. RLS isolates tenant rows; it does not decide whether a user may perform an operation inside the current tenant.
+
+## Required PostgreSQL roles
+
+Use separate administrative and application roles:
+
+- the migration role owns or alters tables, enables and forces RLS, creates policies, and grants the minimum required privileges;
+- the application role must be `NOSUPERUSER`, `NOBYPASSRLS`, and normally must not own tenant tables;
+- background workers and CLI commands that access tenant data must use the same restricted application role.
+
+Never validate isolation as `POSTGRES_USER`, a superuser, or a `BYPASSRLS` role. Those roles bypass policies by design. `FORCE ROW LEVEL SECURITY` additionally subjects table owners to policies, but it does not restrict superusers or `BYPASSRLS`.
+
+
 ## Benefits
 
 - **Defense-in-depth**: Even if Doctrine filters are disabled or bypassed, RLS policies still protect data
@@ -105,11 +131,22 @@ For each tenant-aware table, the command generates:
 ```sql
 -- Enable RLS on the table
 ALTER TABLE products ENABLE ROW LEVEL SECURITY;
+ALTER TABLE products FORCE ROW LEVEL SECURITY;
 
--- Create the isolation policy
+-- Apply the same tenant predicate to reads and writes
 CREATE POLICY tenant_isolation_products ON products
-    USING (tenant_id::text = current_setting('app.tenant_id', true));
+    FOR ALL
+    USING (tenant_id::text = current_setting('app.tenant_id', true))
+    WITH CHECK (tenant_id::text = current_setting('app.tenant_id', true));
 ```
+
+## Session lifecycle, transactions, and pooling
+
+The bundle writes the tenant identifier with session scope so it survives transaction commit or rollback. Every request, message, command iteration, or manually managed tenant operation must set the context before the first tenant-owned query and clear it in a `finally` path. Clearing the PHP tenant context alone is not enough: invoke the session configurator so the PostgreSQL setting is cleared before the connection returns to a pool or handles another tenant.
+
+A newly opened physical connection starts without tenant state and therefore fails closed. Persistent connections and external poolers can reuse physical sessions; configure pool reset behavior and still clear the setting explicitly. Transaction-pooling modes require particular care because session variables may not follow the logical client. Use a pooling mode that preserves the session for the complete tenant operation, or set and verify the tenant setting at the transaction boundary.
+
+The mandatory PostgreSQL suite exercises tenant A/B switching, rollback cleanup, connection reuse, and a newly opened connection. It uses raw DBAL SQL so the proof is independent from the Doctrine filter.
 
 ## Testing RLS Protection
 
@@ -133,8 +170,33 @@ $products = $entityManager->getRepository(Product::class)->findAll();
 - **Shared database only**: Only works with `shared_db` strategy
 - **Performance impact**: RLS policies add overhead to queries
 - **Complex queries**: May need manual policy adjustments for complex scenarios
+- **Partitioning and pooling**: Require deployment-specific policy and session-reset validation
+- **Privileged maintenance**: Must use a separate audited path because privileged roles can bypass RLS
 
 ## Troubleshooting
+
+### Diagnostic checklist
+
+Run these checks with the same database role and connection path used by the application:
+
+```sql
+SELECT current_user,
+       current_setting('app.tenant_id', true) AS tenant_id,
+       rolsuper,
+       rolbypassrls
+FROM pg_roles
+WHERE rolname = current_user;
+
+SELECT relrowsecurity, relforcerowsecurity
+FROM pg_class
+WHERE oid = 'products'::regclass;
+
+SELECT policyname, cmd, qual, with_check
+FROM pg_policies
+WHERE schemaname = 'public' AND tablename = 'products';
+```
+
+Expected application-role values are `rolsuper = false`, `rolbypassrls = false`, and both table flags set to `true`. The policy must include both `qual` and `with_check`.
 
 ### No Data Returned
 
@@ -184,4 +246,4 @@ When migrating from non-RLS to RLS setup:
 3. Test thoroughly in a staging environment
 4. Monitor performance after deployment
 
-The RLS feature is designed to be non-breaking and can be enabled on existing installations without data migration.
+Enabling RLS changes database authorization behavior. Treat it as a security migration: verify role ownership, existing policies, every tenant-owned table, connection pooling, and the mandatory PostgreSQL test suite before production rollout.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,12 +67,6 @@ parameters:
 			path: src/Command/MigrateTenantsCommand.php
 
 		-
-			message: '#^Cannot cast mixed to string\.$#'
-			identifier: cast.string
-			count: 2
-			path: src/Command/SyncRlsPoliciesCommand.php
-
-		-
 			message: '#^Instanceof between ReflectionClass\<object\> and ReflectionClass will always evaluate to true\.$#'
 			identifier: instanceof.alwaysTrue
 			count: 1

--- a/src/Command/SyncRlsPoliciesCommand.php
+++ b/src/Command/SyncRlsPoliciesCommand.php
@@ -198,6 +198,10 @@ HELP
                 $statements[] = sprintf('ALTER TABLE %s ENABLE ROW LEVEL SECURITY;', $this->connection->quoteIdentifier($tableName));
             }
 
+            if (!$rlsEnabled || !$this->isRlsForced($tableName)) {
+                $statements[] = sprintf('ALTER TABLE %s FORCE ROW LEVEL SECURITY;', $this->connection->quoteIdentifier($tableName));
+            }
+
             // Check if policy already exists
             $policyExists = $this->policyExists($tableName, $policyName);
 
@@ -212,19 +216,22 @@ HELP
 
             if (!$policyExists) {
                 $statements[] = sprintf(
-                    'CREATE POLICY %s ON %s USING (tenant_id::text = current_setting(%s, true));',
+                    'CREATE POLICY %s ON %s FOR ALL USING (tenant_id::text = current_setting(%s, true)) WITH CHECK (tenant_id::text = current_setting(%s, true));',
                     (string) $this->connection->quoteIdentifier($policyName),
                     (string) $this->connection->quoteIdentifier($tableName),
+                    (string) $this->connection->quote($this->sessionVariable),
                     (string) $this->connection->quote($this->sessionVariable)
                 );
             }
         } catch (Exception $exception) {
             // If we can't check existing state, generate all statements
             $statements[] = sprintf('ALTER TABLE %s ENABLE ROW LEVEL SECURITY;', $this->connection->quoteIdentifier($tableName));
+            $statements[] = sprintf('ALTER TABLE %s FORCE ROW LEVEL SECURITY;', $this->connection->quoteIdentifier($tableName));
             $statements[] = sprintf(
-                'CREATE POLICY %s ON %s USING (tenant_id::text = current_setting(%s, true));',
+                'CREATE POLICY %s ON %s FOR ALL USING (tenant_id::text = current_setting(%s, true)) WITH CHECK (tenant_id::text = current_setting(%s, true));',
                 (string) $this->connection->quoteIdentifier($policyName),
                 (string) $this->connection->quoteIdentifier($tableName),
+                (string) $this->connection->quote($this->sessionVariable),
                 (string) $this->connection->quote($this->sessionVariable)
             );
         }
@@ -240,6 +247,23 @@ HELP
         try {
             $result = $this->connection->fetchOne(
                 'SELECT relrowsecurity FROM pg_class WHERE relname = ?',
+                [$tableName]
+            );
+
+            return (bool) $result;
+        } catch (Exception) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks whether table owners are subject to RLS.
+     */
+    private function isRlsForced(string $tableName): bool
+    {
+        try {
+            $result = $this->connection->fetchOne(
+                'SELECT relforcerowsecurity FROM pg_class WHERE relname = ?',
                 [$tableName]
             );
 

--- a/src/Command/SyncRlsPoliciesCommand.php
+++ b/src/Command/SyncRlsPoliciesCommand.php
@@ -215,28 +215,44 @@ HELP
             }
 
             if (!$policyExists) {
+                $quotedSessionVariable = $this->quoteSessionVariable();
                 $statements[] = sprintf(
                     'CREATE POLICY %s ON %s FOR ALL USING (tenant_id::text = current_setting(%s, true)) WITH CHECK (tenant_id::text = current_setting(%s, true));',
                     (string) $this->connection->quoteIdentifier($policyName),
                     (string) $this->connection->quoteIdentifier($tableName),
-                    (string) $this->connection->quote($this->sessionVariable),
-                    (string) $this->connection->quote($this->sessionVariable)
+                    $quotedSessionVariable,
+                    $quotedSessionVariable
                 );
             }
         } catch (Exception $exception) {
             // If we can't check existing state, generate all statements
             $statements[] = sprintf('ALTER TABLE %s ENABLE ROW LEVEL SECURITY;', $this->connection->quoteIdentifier($tableName));
             $statements[] = sprintf('ALTER TABLE %s FORCE ROW LEVEL SECURITY;', $this->connection->quoteIdentifier($tableName));
+            $quotedSessionVariable = $this->quoteSessionVariable();
             $statements[] = sprintf(
                 'CREATE POLICY %s ON %s FOR ALL USING (tenant_id::text = current_setting(%s, true)) WITH CHECK (tenant_id::text = current_setting(%s, true));',
                 (string) $this->connection->quoteIdentifier($policyName),
                 (string) $this->connection->quoteIdentifier($tableName),
-                (string) $this->connection->quote($this->sessionVariable),
-                (string) $this->connection->quote($this->sessionVariable)
+                $quotedSessionVariable,
+                $quotedSessionVariable
             );
         }
 
         return $statements;
+    }
+
+    private function quoteSessionVariable(): string
+    {
+        return $this->requireQuotedString($this->connection->quote($this->sessionVariable));
+    }
+
+    private function requireQuotedString(mixed $quotedValue): string
+    {
+        if (!is_string($quotedValue)) {
+            throw new \RuntimeException('The database driver failed to quote the RLS session variable.');
+        }
+
+        return $quotedValue;
     }
 
     /**

--- a/tests/Integration/RlsIsolationTest.php
+++ b/tests/Integration/RlsIsolationTest.php
@@ -101,6 +101,18 @@ final class RlsIsolationTest extends TestCase
         self::assertIsArray($state);
         self::assertTrue($state['relrowsecurity']);
         self::assertTrue($state['relforcerowsecurity']);
+
+        $role = $this->connection->fetchAssociative(<<<'SQL'
+    SELECT r.rolsuper, r.rolbypassrls, pg_get_userbyid(c.relowner) AS table_owner
+    FROM pg_roles r
+    CROSS JOIN pg_class c
+    WHERE r.rolname = current_user
+      AND c.oid = 'test_products'::regclass
+    SQL);
+        self::assertIsArray($role);
+        self::assertFalse($role['rolsuper']);
+        self::assertFalse($role['rolbypassrls']);
+        self::assertNotSame('rls_test_app', $role['table_owner']);
         self::assertSame(1, (int) $this->connection->fetchOne(<<<'SQL'
             SELECT count(*)
             FROM pg_policies
@@ -174,6 +186,77 @@ final class RlsIsolationTest extends TestCase
         }
 
         self::assertNotContains('Cross-tenant attack', $this->visibleProductNames());
+    }
+
+    public function testUpdatesAllowTheCurrentTenantAndHideAnotherTenant(): void
+    {
+        $this->configureTenant($this->tenantA);
+
+        self::assertSame(1, $this->connection->update(
+            'test_products',
+            ['name' => 'Tenant A updated'],
+            ['id' => 1],
+        ));
+        self::assertContains('Tenant A updated', $this->visibleProductNames());
+
+        self::assertSame(0, $this->connection->update(
+            'test_products',
+            ['name' => 'Cross-tenant update'],
+            ['id' => 3],
+        ));
+        self::assertSame(
+            'Tenant B secret',
+            $this->adminConnection->fetchOne('SELECT name FROM test_products WHERE id = 3'),
+        );
+    }
+
+    public function testDeletesAllowTheCurrentTenantAndHideAnotherTenant(): void
+    {
+        $this->configureTenant($this->tenantA);
+
+        self::assertSame(0, $this->connection->delete('test_products', ['id' => 3]));
+        self::assertSame(1, $this->connection->delete('test_products', ['id' => 2]));
+        self::assertSame(['Tenant A product 1'], $this->visibleProductNames());
+        self::assertSame(
+            'Tenant B secret',
+            $this->adminConnection->fetchOne('SELECT name FROM test_products WHERE id = 3'),
+        );
+    }
+
+    public function testFailureCleanupClearsSessionStateBeforeConnectionReuse(): void
+    {
+        $this->configureTenant($this->tenantA);
+        $this->connection->beginTransaction();
+
+        try {
+            self::assertNotEmpty($this->visibleProductNames());
+            throw new \RuntimeException('Simulated tenant operation failure.');
+        } catch (\RuntimeException) {
+            $this->connection->rollBack();
+            $this->tenantContext->clear();
+            $this->sessionConfigurator->setConfig();
+        }
+
+        self::assertSame('', $this->currentTenantSetting());
+        self::assertSame([], $this->visibleProductNames());
+
+        $this->configureTenant($this->tenantB);
+        self::assertSame(['Tenant B secret'], $this->visibleProductNames());
+    }
+
+    public function testAReopenedConnectionHasNoInheritedTenantState(): void
+    {
+        $this->configureTenant($this->tenantA);
+        self::assertNotEmpty($this->visibleProductNames());
+        $this->connection->close();
+
+        $this->connection = DriverManager::getConnection($this->connectionParameters(
+            $_ENV['TEST_DATABASE_APP_USER'] ?? 'rls_test_app',
+            $_ENV['TEST_DATABASE_APP_PASSWORD'] ?? 'rls_test_password',
+        ));
+
+        self::assertSame('', $this->currentTenantSetting());
+        self::assertSame([], $this->visibleProductNames());
     }
 
     public function testMissingContextFailsClosedAndSessionStateIsCleared(): void

--- a/tests/README.md
+++ b/tests/README.md
@@ -123,11 +123,13 @@ public function testCommandWithTenant(): void
 
 #### RlsIsolationTest ⭐
 
-The dedicated suite proves PostgreSQL RLS as a database-level defense:
+The dedicated suite proves PostgreSQL RLS as a database-level defense across SELECT, INSERT, UPDATE, and DELETE:
 
 - PostgreSQL 16 runs in Docker Compose with a PHP 8.3 image containing `pdo_pgsql`.
 - Schema creation and fixtures use the administrative test role.
 - Every isolation assertion uses a separate non-superuser application role, because PostgreSQL superusers bypass RLS even when a table uses `FORCE ROW LEVEL SECURITY`.
+- Same-tenant writes succeed while cross-tenant reads are hidden, cross-tenant updates and deletes affect no rows, and cross-tenant inserts fail.
+- Rollback cleanup, A/B connection reuse, and newly opened connection state fail closed independently from the Doctrine filter.
 - Raw DBAL queries prove same-tenant reads and writes, denied cross-tenant reads and writes, tenant switching, and fail-closed behavior without relying on the Doctrine tenant filter.
 - `TEST_DATABASE_REQUIRED=1` turns environment failures into test failures in the dedicated target instead of skipped tests.
 

--- a/tests/Unit/Command/SyncRlsPoliciesCommandTest.php
+++ b/tests/Unit/Command/SyncRlsPoliciesCommandTest.php
@@ -128,7 +128,9 @@ final class SyncRlsPoliciesCommandTest extends TestCase
 
         $this->assertStringContainsString('Found 1 tenant-aware entities', $output);
         $this->assertStringContainsString('ALTER TABLE "products" ENABLE ROW LEVEL SECURITY', $output);
-        $this->assertStringContainsString('CREATE POLICY "tenant_isolation_products" ON "products"', $output);
+        $this->assertStringContainsString('ALTER TABLE "products" FORCE ROW LEVEL SECURITY', $output);
+        $this->assertStringContainsString('CREATE POLICY "tenant_isolation_products" ON "products" FOR ALL', $output);
+        $this->assertStringContainsString('WITH CHECK (tenant_id::text = current_setting', $output);
         $this->assertStringContainsString('tenant_id::text = current_setting(\'app.tenant_id\', true)', $output);
         $this->assertStringContainsString('Use --apply option to execute', $output);
     }
@@ -176,11 +178,12 @@ final class SyncRlsPoliciesCommandTest extends TestCase
         // Expect SQL statements to be executed
         $expectedCalls = [
             'ALTER TABLE "products" ENABLE ROW LEVEL SECURITY;',
-            'CREATE POLICY "tenant_isolation_products" ON "products" USING (tenant_id::text = current_setting(\'app.tenant_id\', true));',
+            'ALTER TABLE "products" FORCE ROW LEVEL SECURITY;',
+            "CREATE POLICY \"tenant_isolation_products\" ON \"products\" FOR ALL USING (tenant_id::text = current_setting('app.tenant_id', true)) WITH CHECK (tenant_id::text = current_setting('app.tenant_id', true));",
         ];
 
         $this->connection
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(3))
             ->method('executeStatement')
             ->willReturnCallback(function ($sql) use (&$expectedCalls) {
                 $this->assertContains($sql, $expectedCalls);
@@ -191,7 +194,7 @@ final class SyncRlsPoliciesCommandTest extends TestCase
         $exitCode = $this->commandTester->execute(['--apply' => true]);
 
         $this->assertSame(Command::SUCCESS, $exitCode);
-        $this->assertStringContainsString('Successfully applied 2 SQL statements', $this->commandTester->getDisplay());
+        $this->assertStringContainsString('Successfully applied 3 SQL statements', $this->commandTester->getDisplay());
     }
 
     public function testExecuteWithForceOption(): void
@@ -224,7 +227,7 @@ final class SyncRlsPoliciesCommandTest extends TestCase
         // Mock connection methods - RLS enabled, policy exists
         $this->connection
             ->method('fetchOne')
-            ->willReturnOnConsecutiveCalls(true, true); // RLS enabled, policy exists
+            ->willReturnOnConsecutiveCalls(true, true, true); // RLS enabled, forced, and policy exists
 
         $this->connection
             ->method('quoteIdentifier')
@@ -291,6 +294,7 @@ final class SyncRlsPoliciesCommandTest extends TestCase
         $output = $this->commandTester->getDisplay();
 
         $this->assertStringContainsString('ALTER TABLE "products" ENABLE ROW LEVEL SECURITY', $output);
+        $this->assertStringContainsString('ALTER TABLE "products" FORCE ROW LEVEL SECURITY', $output);
         $this->assertStringContainsString('CREATE POLICY "tenant_isolation_products"', $output);
     }
 


### PR DESCRIPTION
Closes #14.

## Problem

The repaired PostgreSQL harness proved real RLS reads and inserts, but the production policy synchronizer still generated only ENABLE ROW LEVEL SECURITY and an implicit read predicate. It did not force table owners through RLS or emit an explicit write predicate. The threat boundary for ORM, DQL, QueryBuilder, DBAL, native SQL, roles, transactions, and pooling was also undocumented.

The earlier pre-remediation state was a false positive: six tests were skipped because no test kernel existed, and the privileged PostgreSQL role would have bypassed RLS. PR #15 replaced that state with a mandatory non-superuser PostgreSQL harness. This PR completes the threat model exposed by that repair.

## Solution

- generate ENABLE and FORCE ROW LEVEL SECURITY for every tenant-owned table;
- generate an explicit FOR ALL policy with matching USING and WITH CHECK predicates;
- retain idempotence by detecting both enabled and forced table state;
- cover the diagnostic-failure fallback with the same secure statements;
- expand the real PostgreSQL suite with same-tenant and denied cross-tenant UPDATE and DELETE scenarios;
- prove rollback cleanup before A/B connection reuse and fail-closed state on a newly opened connection;
- assert that the application role is non-superuser, has no BYPASSRLS, and does not own the protected table;
- document query boundaries, role prerequisites, lifecycle and pool responsibilities, diagnostics, and migration impact.

## Architecture and compatibility

RLS remains optional and PostgreSQL-only under the existing shared_db configuration. No public PHP API, configuration key, dependency, or compatibility constraint changes. Existing policies keep their effective PostgreSQL semantics; run tenant:rls:sync --apply --force to recreate them with the explicit policy form and verify table FORCE state before production rollout.

Superusers and BYPASSRLS roles remain outside the protection boundary by PostgreSQL design. Application authorization and the Doctrine filter remain required layers; the raw DBAL tests deliberately prove isolation independently from the filter.

## Validation

- Composer validate --strict: pass
- PHPStan level max: no errors
- PHPUnit: 435 tests, 1099 assertions; 80 environment-dependent skips and 264 existing notices in the non-PostgreSQL run
- mandatory PostgreSQL 16 RLS suite: 14 tests, 54 assertions
- PHP-CS-Fixer check: clean
- Composer security audit: no advisories

The PostgreSQL suite covers SELECT, INSERT, UPDATE, DELETE, tenant A/B switching, no-context fail-closed behavior, transaction rollback cleanup, connection reuse, new connections, policy metadata, FORCE RLS, and restricted role properties.