### PR TITLE
Prove multi-database isolation in long-running processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,3 +252,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tenant user interface and authentication integration
 - Advanced file storage adapters (S3, etc.)
 - Tenant-specific routing capabilities
+
+- Hardened multi-database long-running processes with fresh tenant EntityManagers, explicit DBAL connection closure, fail-closed context switching, worker cleanup, and real PostgreSQL A/B/A isolation coverage.

--- a/docs/audit-2026-07.md
+++ b/docs/audit-2026-07.md
@@ -118,3 +118,7 @@ The real database tests also exposed an implementation defect: `TenantSessionCon
 Issue #14 extended the effective PostgreSQL suite from 10 tests and 30 assertions to 14 tests and 54 assertions. The new adversarial coverage proves allowed same-tenant and hidden cross-tenant UPDATE and DELETE behavior, rollback cleanup before connection reuse, and fail-closed state on a newly opened application connection. The policy generator now emits both `ENABLE ROW LEVEL SECURITY` and `FORCE ROW LEVEL SECURITY`, with an explicit `FOR ALL` policy containing matching `USING` and `WITH CHECK` predicates.
 
 The security guide now distinguishes ORM filter coverage from DQL, QueryBuilder, DBAL, and native SQL boundaries; defines restricted application-role requirements; and documents transaction, worker, CLI, persistent-connection, and pool-reset responsibilities. Superusers and roles with `BYPASSRLS` remain intentionally outside the RLS protection boundary.
+
+### Multi-database long-running isolation
+
+Issue #11 replaces the previous unproven multi-database lifecycle with real PostgreSQL A/B/A coverage. The regression suite uses two physical databases, proves that markers cannot cross database boundaries, and verifies that a connection is closed when tenant work throws. Schema, migration, fixture, and Messenger paths now clear tenant context between iterations; tenant-specific EntityManagers explicitly close their DBAL connections because closing the ORM EntityManager alone did not reliably close the physical connection.

--- a/docs/database-strategies.md
+++ b/docs/database-strategies.md
@@ -791,3 +791,8 @@ php bin/console tenant:schema:validate --all-tenants
 ---
 
 > 📖 **Navigation**: [← CLI Commands](cli.md) | [Back to Documentation Index](index.md) | [Doctrine Tenant Filter →](doctrine-tenant-filter.md)
+## Long-running process lifecycle
+
+Multi-database work must resolve and switch the database before publishing the new tenant context. Use TenantEntityManagerFactory::runForTenant() for manual tenant operations; it creates a fresh EntityManager and explicitly clears and closes both the EntityManager and its DBAL connection in a finally path. Do not cache tenant EntityManagers or connections across requests, messages, command iterations, or jobs.
+
+Messenger workers and tenant-looping commands must begin each operation without state from the previous tenant. Resolution failures must leave no new tenant context, and every success, exception, early return, and skipped operation must clear the context. External connection pools still require a reset policy appropriate to the driver and pooler.

--- a/src/Command/CreateTenantSchemaCommand.php
+++ b/src/Command/CreateTenantSchemaCommand.php
@@ -92,33 +92,30 @@ EOT
             foreach ($tenants as $tenant) {
                 $io->section(sprintf('Creating schema for tenant: %s', $tenant->getSlug()));
 
-                // Set tenant context
+                // Switch first so a failed resolution cannot publish a stale context.
+                $this->connectionResolver->switchToTenantConnection($tenant);
                 $this->tenantContext->setTenant($tenant);
 
-                // Switch to tenant connection
-                $this->connectionResolver->switchToTenantConnection($tenant);
+                $this->entityManagerFactory->runForTenant(
+                    $tenant,
+                    function (EntityManagerInterface $tenantEntityManager) use ($dumpSql, $io, $metadatas, $tenant): void {
+                        $schemaTool = new SchemaTool($tenantEntityManager);
 
-                // Create tenant-specific entity manager
-                $tenantEntityManager = $this->entityManagerFactory->createForTenant($tenant);
-
-                // Create schema tool
-                $schemaTool = new SchemaTool($tenantEntityManager);
-
-                if ($dumpSql) {
-                    $sqls = $schemaTool->getCreateSchemaSql($metadatas);
-                    if (!empty($sqls)) {
-                        $io->text(sprintf('SQL for tenant %s:', $tenant->getSlug()));
-                        $io->block($sqls);
-                    } else {
-                        $io->note(sprintf('No SQL to execute for tenant %s', $tenant->getSlug()));
+                        if ($dumpSql) {
+                            $sqls = $schemaTool->getCreateSchemaSql($metadatas);
+                            if (!empty($sqls)) {
+                                $io->text(sprintf('SQL for tenant %s:', $tenant->getSlug()));
+                                $io->block($sqls);
+                            } else {
+                                $io->note(sprintf('No SQL to execute for tenant %s', $tenant->getSlug()));
+                            }
+                        } else {
+                            $schemaTool->createSchema($metadatas);
+                            $io->success(sprintf('Successfully created schema for tenant %s', $tenant->getSlug()));
+                        }
                     }
-                } else {
-                    $schemaTool->createSchema($metadatas);
-                    $io->success(sprintf('Successfully created schema for tenant %s', $tenant->getSlug()));
-                }
-
-                // Close the tenant entity manager
-                $tenantEntityManager->close();
+                );
+                $this->tenantContext->clear();
             }
 
             if ($dumpSql) {

--- a/src/Command/DropTenantSchemaCommand.php
+++ b/src/Command/DropTenantSchemaCommand.php
@@ -112,39 +112,36 @@ EOT
             foreach ($tenants as $tenant) {
                 $io->section(sprintf('Dropping schema for tenant: %s', $tenant->getSlug()));
 
-                // Set tenant context
+                // Switch first so a failed resolution cannot publish a stale context.
+                $this->connectionResolver->switchToTenantConnection($tenant);
                 $this->tenantContext->setTenant($tenant);
 
-                // Switch to tenant connection
-                $this->connectionResolver->switchToTenantConnection($tenant);
+                $this->entityManagerFactory->runForTenant(
+                    $tenant,
+                    function (EntityManagerInterface $tenantEntityManager) use ($dumpSql, $fullDatabase, $io, $metadata, $tenant): void {
+                        $schemaTool = new SchemaTool($tenantEntityManager);
 
-                // Create tenant-specific entity manager
-                $tenantEntityManager = $this->entityManagerFactory->createForTenant($tenant);
+                        if ($dumpSql) {
+                            $sql = $fullDatabase
+                                ? $schemaTool->getDropDatabaseSQL()
+                                : $schemaTool->getDropSchemaSQL($metadata);
 
-                // Create schema tool
-                $schemaTool = new SchemaTool($tenantEntityManager);
-
-                if ($dumpSql) {
-                    $sql = $fullDatabase
-                        ? $schemaTool->getDropDatabaseSQL()
-                        : $schemaTool->getDropSchemaSQL($metadata);
-
-                    if (!empty($sql)) {
-                        $io->text(sprintf('SQL for tenant %s:', $tenant->getSlug()));
-                        $io->block($sql);
-                    } else {
-                        $io->note(sprintf('No SQL to execute for tenant %s', $tenant->getSlug()));
+                            if (!empty($sql)) {
+                                $io->text(sprintf('SQL for tenant %s:', $tenant->getSlug()));
+                                $io->block($sql);
+                            } else {
+                                $io->note(sprintf('No SQL to execute for tenant %s', $tenant->getSlug()));
+                            }
+                        } elseif ($fullDatabase) {
+                            $schemaTool->dropDatabase();
+                            $io->success(sprintf('Successfully dropped database for tenant %s', $tenant->getSlug()));
+                        } else {
+                            $schemaTool->dropSchema($metadata);
+                            $io->success(sprintf('Successfully dropped schema for tenant %s', $tenant->getSlug()));
+                        }
                     }
-                } elseif ($fullDatabase) {
-                    $schemaTool->dropDatabase();
-                    $io->success(sprintf('Successfully dropped database for tenant %s', $tenant->getSlug()));
-                } else {
-                    $schemaTool->dropSchema($metadata);
-                    $io->success(sprintf('Successfully dropped schema for tenant %s', $tenant->getSlug()));
-                }
-
-                // Close the tenant entity manager
-                $tenantEntityManager->close();
+                );
+                $this->tenantContext->clear();
             }
 
             if ($dumpSql) {

--- a/src/Command/LoadTenantFixturesCommand.php
+++ b/src/Command/LoadTenantFixturesCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Zhortein\MultiTenantBundle\Context\TenantContextInterface;
 use Zhortein\MultiTenantBundle\Doctrine\TenantConnectionResolverInterface;
+use Zhortein\MultiTenantBundle\Doctrine\TenantEntityManagerFactory;
 use Zhortein\MultiTenantBundle\Registry\TenantRegistryInterface;
 
 /**
@@ -37,6 +38,7 @@ class LoadTenantFixturesCommand extends AbstractTenantAwareCommand
         private readonly TenantConnectionResolverInterface $connectionResolver,
         private readonly EntityManagerInterface $entityManager,
         private readonly ?object $fixturesLoader = null, // SymfonyFixturesLoader when available
+        private readonly ?TenantEntityManagerFactory $entityManagerFactory = null,
     ) {
         parent::__construct($tenantRegistry, $tenantContext);
     }
@@ -116,61 +118,69 @@ EOT
             }
 
             $io->title('Tenant Fixtures Loading');
+            $entityManagerFactory = $this->entityManagerFactory ?? new TenantEntityManagerFactory(
+                $this->connectionResolver,
+                $this->entityManager->getConfiguration()
+            );
 
             foreach ($tenants as $tenant) {
                 $io->section(sprintf('Loading fixtures for tenant: %s', $tenant->getSlug()));
 
-                // Set tenant context
-                $this->tenantContext->setTenant($tenant);
-
-                // Switch to tenant connection
                 $this->connectionResolver->switchToTenantConnection($tenant);
+                $this->tenantContext->setTenant($tenant);
 
                 // Confirm before purging data (unless appending)
                 if (!$append && !$this->confirmPurge($io, $tenant->getSlug())) {
                     $io->note(sprintf('Skipping fixtures for tenant %s', $tenant->getSlug()));
+                    $this->tenantContext->clear();
                     continue;
                 }
 
-                // Create purger - using dynamic class instantiation
-                $purgerClass = 'Doctrine\\Common\\DataFixtures\\Purger\\ORMPurger';
-                if (!class_exists($purgerClass)) {
-                    $io->error('ORMPurger class not found. Please install doctrine/doctrine-fixtures-bundle.');
+                $entityManagerFactory->runForTenant(
+                    $tenant,
+                    function (EntityManagerInterface $tenantEntityManager) use ($append, $fixtures, $io, $purgeExclusions, $purgeWithTruncate, $tenant): void {
+                        // Create purger - using dynamic class instantiation
+                        $purgerClass = 'Doctrine\\Common\\DataFixtures\\Purger\\ORMPurger';
+                        if (!class_exists($purgerClass)) {
+                            $io->error('ORMPurger class not found. Please install doctrine/doctrine-fixtures-bundle.');
 
-                    return Command::FAILURE;
-                }
+                            throw new \RuntimeException('The tenant fixture runtime is unavailable.');
+                        }
 
-                /** @phpstan-ignore-next-line */
-                $purger = new $purgerClass($this->entityManager);
-                $purgeMode = $purgeWithTruncate ? 2 : 1; // PURGE_MODE_TRUNCATE : PURGE_MODE_DELETE
-                /* @phpstan-ignore-next-line */
-                $purger->setPurgeMode($purgeMode);
+                        /** @phpstan-ignore-next-line */
+                        $purger = new $purgerClass($tenantEntityManager);
+                        $purgeMode = $purgeWithTruncate ? 2 : 1; // PURGE_MODE_TRUNCATE : PURGE_MODE_DELETE
+                        /* @phpstan-ignore-next-line */
+                        $purger->setPurgeMode($purgeMode);
 
-                if (!empty($purgeExclusions)) {
-                    /* @phpstan-ignore-next-line */
-                    $purger->setExclusions($purgeExclusions);
-                }
+                        if (!empty($purgeExclusions)) {
+                            /* @phpstan-ignore-next-line */
+                            $purger->setExclusions($purgeExclusions);
+                        }
 
-                // Create executor
-                $executorClass = 'Doctrine\\Common\\DataFixtures\\Executor\\ORMExecutor';
-                if (!class_exists($executorClass)) {
-                    $io->error('ORMExecutor class not found. Please install doctrine/doctrine-fixtures-bundle.');
+                        // Create executor
+                        $executorClass = 'Doctrine\\Common\\DataFixtures\\Executor\\ORMExecutor';
+                        if (!class_exists($executorClass)) {
+                            $io->error('ORMExecutor class not found. Please install doctrine/doctrine-fixtures-bundle.');
 
-                    return Command::FAILURE;
-                }
-                /** @phpstan-ignore-next-line */
-                $executor = new $executorClass($this->entityManager, $purger);
+                            throw new \RuntimeException('The tenant fixture runtime is unavailable.');
+                        }
+                        /** @phpstan-ignore-next-line */
+                        $executor = new $executorClass($tenantEntityManager, $purger);
 
-                // Execute fixtures
-                /* @phpstan-ignore-next-line */
-                $executor->execute($fixtures, $append);
+                        // Execute fixtures
+                        /* @phpstan-ignore-next-line */
+                        $executor->execute($fixtures, $append);
 
-                $io->success(sprintf(
-                    'Successfully loaded %d fixtures for tenant %s',
-                    /* @phpstan-ignore-next-line */
-                    count($fixtures),
-                    $tenant->getSlug()
-                ));
+                        $io->success(sprintf(
+                            'Successfully loaded %d fixtures for tenant %s',
+                            /* @phpstan-ignore-next-line */
+                            count($fixtures),
+                            $tenant->getSlug()
+                        ));
+                    }
+                );
+                $this->tenantContext->clear();
             }
 
             $io->success('Tenant fixtures loading completed successfully.');

--- a/src/Command/MigrateTenantsCommand.php
+++ b/src/Command/MigrateTenantsCommand.php
@@ -154,63 +154,54 @@ EOT
 
         foreach ($tenants as $tenant) {
             $io->section(sprintf('Migrating tenant: %s', $tenant->getSlug()));
+            $dependencyFactory = null;
 
-            // Set tenant context
-            $this->tenantContext->setTenant($tenant);
+            try {
+                $this->connectionResolver->switchToTenantConnection($tenant);
+                $this->tenantContext->setTenant($tenant);
 
-            // Switch to tenant connection
-            $this->connectionResolver->switchToTenantConnection($tenant);
+                $connectionParams = $this->connectionResolver->resolveParameters($tenant);
+                $dependencyFactory = $this->createTenantDependencyFactory($connectionParams);
+                $migrator = $dependencyFactory->getMigrator();
+                $migrations = $dependencyFactory->getMigrationRepository()->getMigrations();
 
-            // Get connection parameters for this tenant
-            $connectionParams = $this->connectionResolver->resolveParameters($tenant);
+                if (0 === $migrations->count()) {
+                    if ($allowNoMigration) {
+                        $io->note(sprintf('No migrations found for tenant %s', $tenant->getSlug()));
+                        continue;
+                    }
 
-            // Create tenant-specific dependency factory
-            $dependencyFactory = $this->createTenantDependencyFactory($connectionParams);
+                    $io->error(sprintf('No migrations found for tenant %s', $tenant->getSlug()));
 
-            // Execute migrations
-            $migrator = $dependencyFactory->getMigrator();
-            $migrations = $dependencyFactory->getMigrationRepository()->getMigrations();
+                    return Command::FAILURE;
+                }
 
-            if (0 === $migrations->count()) {
-                if ($allowNoMigration) {
-                    $io->note(sprintf('No migrations found for tenant %s', $tenant->getSlug()));
+                $planCalculator = $dependencyFactory->getMigrationPlanCalculator();
+                /** @phpstan-ignore-next-line */
+                $plan = $planCalculator->getPlanToMigrateUp();
+
+                if ($dryRun) {
+                    $io->note('Executing migration as dry run...');
+
+                    if ($plan->count() > 0) {
+                        $io->text('SQL that would be executed:');
+                        /* @phpstan-ignore-next-line */
+                        foreach ($plan->getItems() as $item) {
+                            /* @phpstan-ignore-next-line */
+                            $io->text(sprintf('-- Migration: %s', $item->getVersion()));
+                            $io->text('-- SQL queries would be shown here in a real implementation');
+                        }
+                    } else {
+                        $io->success('No migrations to execute.');
+                    }
+
                     continue;
                 }
 
-                $io->error(sprintf('No migrations found for tenant %s', $tenant->getSlug()));
-
-                return Command::FAILURE;
-            }
-
-            if ($dryRun) {
-                $io->note('Executing migration as dry run...');
-                // For dry run, we need to get the plan and show SQL
-                $planCalculator = $dependencyFactory->getMigrationPlanCalculator();
-                /** @phpstan-ignore-next-line */
-                $plan = $planCalculator->getPlanToMigrateUp();
-
-                if ($plan->count() > 0) {
-                    $io->text('SQL that would be executed:');
-                    /* @phpstan-ignore-next-line */
-                    foreach ($plan->getItems() as $item) {
-                        /* @phpstan-ignore-next-line */
-                        $io->text(sprintf('-- Migration: %s', $item->getVersion()));
-                        // Note: Actual SQL queries would require executing the migration
-                        $io->text('-- SQL queries would be shown here in a real implementation');
-                    }
-                } else {
-                    $io->success('No migrations to execute.');
-                }
-            } else {
-                // Execute migrations
-                $planCalculator = $dependencyFactory->getMigrationPlanCalculator();
-                /** @phpstan-ignore-next-line */
-                $plan = $planCalculator->getPlanToMigrateUp();
-
                 /* @phpstan-ignore-next-line */
                 if ($plan->count() > 0) {
-                    /** @phpstan-ignore-next-line */
-                    $result = $migrator->migrate($plan, $dryRun);
+                    /* @phpstan-ignore-next-line */
+                    $migrator->migrate($plan, false);
                     $io->success(sprintf(
                         'Successfully executed %d migrations for tenant %s',
                         /* @phpstan-ignore-next-line */
@@ -220,6 +211,12 @@ EOT
                 } else {
                     $io->note(sprintf('No migrations to execute for tenant %s', $tenant->getSlug()));
                 }
+            } finally {
+                if (null !== $dependencyFactory) {
+                    $dependencyFactory->getConnection()->close();
+                }
+
+                $this->tenantContext->clear();
             }
         }
 

--- a/src/Database/TenantSessionConfigurator.php
+++ b/src/Database/TenantSessionConfigurator.php
@@ -109,6 +109,16 @@ final readonly class TenantSessionConfigurator implements MiddlewareInterface
     }
 
     /**
+     * Clears the configured tenant session before a connection is reused.
+     */
+    public function clearConfig(): void
+    {
+        if ($this->rlsEnabled) {
+            $this->clearTenantSession();
+        }
+    }
+
+    /**
      * Configures the PostgreSQL session variable with current tenant ID.
      */
     private function configureTenantSession(): void

--- a/src/Doctrine/TenantEntityManagerFactory.php
+++ b/src/Doctrine/TenantEntityManagerFactory.php
@@ -43,6 +43,32 @@ final readonly class TenantEntityManagerFactory
     }
 
     /**
+     * Executes work with a fresh tenant-specific entity manager.
+     *
+     * The entity manager and its connection are always cleared and closed before
+     * control returns to the caller, including when tenant work throws.
+     *
+     * @template TResult
+     *
+     * @param callable(EntityManagerInterface): TResult $operation
+     *
+     * @return TResult
+     */
+    public function runForTenant(TenantInterface $tenant, callable $operation): mixed
+    {
+        $entityManager = $this->createForTenant($tenant);
+
+        try {
+            return $operation($entityManager);
+        } finally {
+            $connection = $entityManager->getConnection();
+            $entityManager->clear();
+            $entityManager->close();
+            $connection->close();
+        }
+    }
+
+    /**
      * Creates entity managers for multiple tenants.
      *
      * @param array<TenantInterface> $tenants The tenants to create entity managers for

--- a/src/Messenger/TenantWorkerMiddleware.php
+++ b/src/Messenger/TenantWorkerMiddleware.php
@@ -9,6 +9,7 @@ use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 use Zhortein\MultiTenantBundle\Context\TenantContextInterface;
 use Zhortein\MultiTenantBundle\Database\TenantSessionConfigurator;
+use Zhortein\MultiTenantBundle\Doctrine\TenantConnectionResolverInterface;
 use Zhortein\MultiTenantBundle\Registry\TenantRegistryInterface;
 
 /**
@@ -24,11 +25,16 @@ final readonly class TenantWorkerMiddleware implements MiddlewareInterface
         private TenantContextInterface $tenantContext,
         private TenantRegistryInterface $tenantRegistry,
         private TenantSessionConfigurator $sessionConfigurator,
+        private ?TenantConnectionResolverInterface $connectionResolver = null,
     ) {
     }
 
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
+        // A reused worker must start without state from the previous message.
+        $this->tenantContext->clear();
+        $this->sessionConfigurator->clearConfig();
+
         $tenantStamp = $envelope->last(TenantStamp::class);
 
         if (!$tenantStamp instanceof TenantStamp) {
@@ -44,7 +50,8 @@ final readonly class TenantWorkerMiddleware implements MiddlewareInterface
             return $stack->next()->handle($envelope, $stack);
         }
 
-        // Set tenant context
+        // Switch before publishing the context so resolution failures fail closed.
+        $this->connectionResolver?->switchToTenantConnection($tenant);
         $this->tenantContext->setTenant($tenant);
 
         try {
@@ -54,8 +61,9 @@ final readonly class TenantWorkerMiddleware implements MiddlewareInterface
             // Process the message with tenant context
             return $stack->next()->handle($envelope, $stack);
         } finally {
-            // Always clear tenant context after processing
+            // Always clear both PHP and database session state after processing.
             $this->tenantContext->clear();
+            $this->sessionConfigurator->clearConfig();
         }
     }
 }

--- a/tests/Dockerfile.rls
+++ b/tests/Dockerfile.rls
@@ -1,4 +1,5 @@
-FROM php:8.3-cli
+ARG PHP_VERSION=8.3
+FROM php:${PHP_VERSION}-cli
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libpq-dev \

--- a/tests/Integration/MultiDatabaseIsolationTest.php
+++ b/tests/Integration/MultiDatabaseIsolationTest.php
@@ -143,10 +143,13 @@ final class MultiDatabaseIsolationTest extends TestCase
             }
         };
 
-        return new TenantEntityManagerFactory(
-            $resolver,
-            ORMSetup::createAttributeMetadataConfiguration([], true)
-        );
+        $ormConfiguration = ORMSetup::createAttributeMetadataConfiguration([], true);
+
+        if (PHP_VERSION_ID >= 80400) {
+            $ormConfiguration->enableNativeLazyObjects(true);
+        }
+
+        return new TenantEntityManagerFactory($resolver, $ormConfiguration);
     }
 
     /** @return list<string> */

--- a/tests/Integration/MultiDatabaseIsolationTest.php
+++ b/tests/Integration/MultiDatabaseIsolationTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zhortein\MultiTenantBundle\Tests\Integration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\ORMSetup;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Zhortein\MultiTenantBundle\Doctrine\TenantConnectionResolverInterface;
+use Zhortein\MultiTenantBundle\Doctrine\TenantEntityManagerFactory;
+use Zhortein\MultiTenantBundle\Entity\TenantInterface;
+use Zhortein\MultiTenantBundle\Tests\Fixtures\Entity\TestTenant;
+
+#[Group('rls')]
+final class MultiDatabaseIsolationTest extends TestCase
+{
+    private Connection $adminConnection;
+
+    /** @var array<string, mixed> */
+    private array $baseParameters;
+
+    protected function setUp(): void
+    {
+        $this->baseParameters = [
+            'driver' => 'pdo_pgsql',
+            'host' => $this->environment('TEST_DATABASE_HOST', '127.0.0.1'),
+            'port' => (int) $this->environment('TEST_DATABASE_PORT', '5432'),
+            'dbname' => $this->environment('TEST_DATABASE_NAME', 'multi_tenant_test'),
+            'user' => $this->environment('TEST_DATABASE_USER', 'test_user'),
+            'password' => $this->environment('TEST_DATABASE_PASSWORD', 'test_password'),
+        ];
+
+        try {
+            $this->adminConnection = DriverManager::getConnection($this->baseParameters);
+            $this->adminConnection->executeQuery('SELECT 1');
+        } catch (\Throwable $exception) {
+            if ('1' === $this->environment('TEST_DATABASE_REQUIRED', '0')) {
+                self::fail('The required PostgreSQL multi-database test environment is unavailable: '.$exception->getMessage());
+            }
+
+            self::markTestSkipped('PostgreSQL is required for multi-database isolation tests.');
+        }
+
+        foreach (['multi_tenant_a_test', 'multi_tenant_b_test'] as $databaseName) {
+            if (false === $this->adminConnection->fetchOne('SELECT 1 FROM pg_database WHERE datname = ?', [$databaseName])) {
+                $this->adminConnection->executeStatement(sprintf('CREATE DATABASE %s', $this->adminConnection->quoteIdentifier($databaseName)));
+            }
+
+            $connection = DriverManager::getConnection(array_merge($this->baseParameters, ['dbname' => $databaseName]));
+            $connection->executeStatement('CREATE TABLE IF NOT EXISTS isolation_probe (marker VARCHAR(64) NOT NULL)');
+            $connection->executeStatement('TRUNCATE isolation_probe');
+            $connection->close();
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->adminConnection)) {
+            $this->adminConnection->close();
+        }
+    }
+
+    public function testFreshConnectionsPreserveIsolationAcrossTenantRotation(): void
+    {
+        $tenantA = (new TestTenant())->setId(101)->setSlug('tenant-a')->setName('Tenant A');
+        $tenantB = (new TestTenant())->setId(202)->setSlug('tenant-b')->setName('Tenant B');
+        $factory = $this->factory();
+
+        $connectionIds = [];
+        $databases = [];
+
+        foreach ([[$tenantA, 'A-1'], [$tenantB, 'B-1'], [$tenantA, 'A-2']] as [$tenant, $marker]) {
+            $databases[] = $factory->runForTenant(
+                $tenant,
+                function (EntityManagerInterface $entityManager) use (&$connectionIds, $marker): string {
+                    $connection = $entityManager->getConnection();
+                    $connectionIds[] = spl_object_id($connection);
+                    $connection->insert('isolation_probe', ['marker' => $marker]);
+
+                    return (string) $connection->fetchOne('SELECT current_database()');
+                }
+            );
+        }
+
+        self::assertSame(['multi_tenant_a_test', 'multi_tenant_b_test', 'multi_tenant_a_test'], $databases);
+        self::assertCount(3, array_unique($connectionIds));
+        self::assertSame(['A-1', 'A-2'], $this->markers('multi_tenant_a_test'));
+        self::assertSame(['B-1'], $this->markers('multi_tenant_b_test'));
+        self::assertNotContains('B-1', $this->markers('multi_tenant_a_test'));
+        self::assertNotContains('A-1', $this->markers('multi_tenant_b_test'));
+    }
+
+    public function testConnectionClosesWhenTenantWorkFails(): void
+    {
+        $tenant = (new TestTenant())->setId(101)->setSlug('tenant-a')->setName('Tenant A');
+        $capturedConnection = null;
+
+        try {
+            $this->factory()->runForTenant(
+                $tenant,
+                static function (EntityManagerInterface $entityManager) use (&$capturedConnection): never {
+                    $capturedConnection = $entityManager->getConnection();
+                    $capturedConnection->executeQuery('SELECT 1');
+
+                    throw new \RuntimeException('Tenant operation failed.');
+                }
+            );
+            self::fail('The tenant exception should have propagated.');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('Tenant operation failed.', $exception->getMessage());
+        }
+
+        self::assertInstanceOf(Connection::class, $capturedConnection);
+        self::assertFalse($capturedConnection->isConnected());
+    }
+
+    private function factory(): TenantEntityManagerFactory
+    {
+        $parameters = $this->baseParameters;
+        $resolver = new class($parameters) implements TenantConnectionResolverInterface {
+            /** @param array<string, mixed> $parameters */
+            public function __construct(private readonly array $parameters)
+            {
+            }
+
+            public function resolveParameters(TenantInterface $tenant): array
+            {
+                $database = match ($tenant->getSlug()) {
+                    'tenant-a' => 'multi_tenant_a_test',
+                    'tenant-b' => 'multi_tenant_b_test',
+                    default => throw new \InvalidArgumentException('No database is configured for tenant "'.$tenant->getSlug().'".'),
+                };
+
+                return array_merge($this->parameters, ['dbname' => $database]);
+            }
+
+            public function switchToTenantConnection(TenantInterface $tenant): void
+            {
+            }
+        };
+
+        return new TenantEntityManagerFactory(
+            $resolver,
+            ORMSetup::createAttributeMetadataConfiguration([], true)
+        );
+    }
+
+    /** @return list<string> */
+    private function markers(string $databaseName): array
+    {
+        $connection = DriverManager::getConnection(array_merge($this->baseParameters, ['dbname' => $databaseName]));
+
+        try {
+            return array_values(array_map(
+                static fn (array $row): string => (string) $row['marker'],
+                $connection->fetchAllAssociative('SELECT marker FROM isolation_probe ORDER BY marker')
+            ));
+        } finally {
+            $connection->close();
+        }
+    }
+
+    private function environment(string $name, string $default): string
+    {
+        $value = $_SERVER[$name] ?? $_ENV[$name] ?? getenv($name);
+
+        return is_string($value) && '' !== $value ? $value : $default;
+    }
+}

--- a/tests/Messenger/TenantWorkerMiddlewareTest.php
+++ b/tests/Messenger/TenantWorkerMiddlewareTest.php
@@ -34,9 +34,7 @@ class TenantWorkerMiddlewareTest extends TestCase
 
         // Create a real TenantSessionConfigurator with mocked dependencies
         $connection = $this->createMock(Connection::class);
-        $platform = $this->createMock(\Doctrine\DBAL\Platforms\AbstractPlatform::class);
-        $platform->method('getName')->willReturn('postgresql');
-        $connection->method('getDatabasePlatform')->willReturn($platform);
+        $connection->method('getDatabasePlatform')->willReturn(new \Doctrine\DBAL\Platforms\PostgreSQLPlatform());
 
         $logger = $this->createMock(LoggerInterface::class);
 
@@ -76,7 +74,7 @@ class TenantWorkerMiddlewareTest extends TestCase
             ->method('setTenant')
             ->with($tenant);
 
-        $this->tenantContext->expects($this->once())
+        $this->tenantContext->expects($this->exactly(2))
             ->method('clear');
 
         $nextMiddleware = $this->createMock(\Symfony\Component\Messenger\Middleware\MiddlewareInterface::class);
@@ -108,7 +106,7 @@ class TenantWorkerMiddlewareTest extends TestCase
         $this->tenantContext->expects($this->never())
             ->method('setTenant');
 
-        $this->tenantContext->expects($this->never())
+        $this->tenantContext->expects($this->once())
             ->method('clear');
 
         $nextMiddleware = $this->createMock(\Symfony\Component\Messenger\Middleware\MiddlewareInterface::class);
@@ -144,7 +142,7 @@ class TenantWorkerMiddlewareTest extends TestCase
         $this->tenantContext->expects($this->never())
             ->method('setTenant');
 
-        $this->tenantContext->expects($this->never())
+        $this->tenantContext->expects($this->once())
             ->method('clear');
 
         $nextMiddleware = $this->createMock(\Symfony\Component\Messenger\Middleware\MiddlewareInterface::class);
@@ -195,7 +193,7 @@ class TenantWorkerMiddlewareTest extends TestCase
             ->willThrowException($exception);
 
         // Expect clear to be called even when exception is thrown
-        $this->tenantContext->expects($this->once())
+        $this->tenantContext->expects($this->exactly(2))
             ->method('clear');
 
         // Act & Assert
@@ -223,7 +221,7 @@ class TenantWorkerMiddlewareTest extends TestCase
             ->method('setTenant')
             ->with($tenant);
 
-        $this->tenantContext->expects($this->once())
+        $this->tenantContext->expects($this->exactly(2))
             ->method('clear');
 
         $nextMiddleware = $this->createMock(\Symfony\Component\Messenger\Middleware\MiddlewareInterface::class);
@@ -263,7 +261,7 @@ class TenantWorkerMiddlewareTest extends TestCase
             ->method('setTenant')
             ->with($tenant);
 
-        $this->tenantContext->expects($this->once())
+        $this->tenantContext->expects($this->exactly(2))
             ->method('clear');
 
         $nextMiddleware = $this->createMock(\Symfony\Component\Messenger\Middleware\MiddlewareInterface::class);

--- a/tests/README.md
+++ b/tests/README.md
@@ -405,3 +405,6 @@ php -m | grep pdo_pgsql  # Ensure PostgreSQL extension is loaded
 ```
 
 The Test Kit ensures your multi-tenant application is bulletproof with comprehensive testing at every level! 🛡️
+### Multi-database isolation
+
+The mandatory PostgreSQL run also creates two dedicated test databases and executes an A/B/A tenant rotation. It asserts distinct DBAL connection objects, the effective PostgreSQL database name, cross-database data separation, and connection closure after exceptions. The PostgreSQL provisioning user must be allowed to create the two disposable test databases.


### PR DESCRIPTION
Closes #11\n\n## Problem\n\nMulti-database factories existed, but long-running A/B/A tenant rotation, exception cleanup, and physical connection closure were not proven. Schema, migration, fixture, and Messenger paths could retain tenant state, and closing an ORM EntityManager alone did not reliably close its DBAL connection.\n\n## Solution\n\n- add a tenant-scoped EntityManager operation that always clears the ORM and explicitly closes the DBAL connection;\n- use fresh tenant EntityManagers in schema and fixture operations;\n- close migration connections and clear context in per-tenant finally paths;\n- make Messenger workers clear stale PHP and PostgreSQL session state before and after each message and switch databases before publishing the new context;\n- ensure skipped fixture operations also clear context;\n- document lifecycle and pool responsibilities.\n\n## Architecture and compatibility\n\nThe existing TenantConnectionResolverInterface is unchanged. TenantEntityManagerFactory::runForTenant() and TenantSessionConfigurator::clearConfig() are additive APIs. The optional Messenger resolver argument preserves existing manual construction. No database strategy or resolver default changes.\n\n## Effective PostgreSQL coverage\n\nThe new integration test provisions two real PostgreSQL databases and rotates tenant A / tenant B / tenant A. It verifies:\n\n- the effective current_database() for every operation;\n- a distinct DBAL connection object per operation;\n- same-tenant reads and writes;\n- absence of cross-database markers;\n- explicit physical connection closure after an exception.\n\nThe test exposed and now prevents the previous EntityManager-close false assumption.\n\n## Validation\n\n- Composer validation: pass\n- Composer security audit: no advisories\n- PHPStan maximum level: pass\n- PHP-CS-Fixer check: pass\n- PHPUnit: 437 tests, 1,099 assertions (82 existing skips)\n- Effective PostgreSQL suite: 16 tests, 63 assertions, no skips\n