### PR TITLE
Fix Mailer Defaults and Messenger Tenant Propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a migration guide for these intentional pre-1.0 security-related breaking changes.
 
 ### Fixed
+- Made tenant setting fallbacks truly optional so Mailer configuration no longer fails when an unset optional default parameter is absent.
+- Registered the documented Messenger sending and worker middleware, preserved tenant context during outgoing dispatch, restored it only for received messages, and prevented duplicate tenant stamps.
 - Enforced PostgreSQL RLS for table owners with explicit read/write predicates and expanded real-database coverage for UPDATE, DELETE, rollback cleanup, and connection reuse.
 - Kept tenant-aware Symfony cache decorators compatible with traceable adapters while preserving same-tenant access and cross-tenant namespace isolation.
 - Registered a contract-correct aggregate Mailer transport factory and mapped `TenantInterface` to the configured tenant entity so real consumer containers and Doctrine metadata validate successfully.

--- a/docs/messenger.md
+++ b/docs/messenger.md
@@ -131,8 +131,8 @@ public function configureMessenger(TenantSettingsManager $settings): void
 
 The tenant propagation middleware is automatically registered when the bundle is enabled. The middleware stack includes:
 
-1. **TenantSendingMiddleware** (Priority: 100) - Attaches tenant context to outgoing messages
-2. **TenantWorkerMiddleware** (Priority: 100) - Restores tenant context in workers
+1. **TenantWorkerMiddleware** (Priority: 200) - Restores tenant context for received messages
+2. **TenantSendingMiddleware** (Priority: 150) - Attaches tenant context to outgoing messages
 3. **TenantMessengerTransportResolver** (Priority: 100) - Routes messages to tenant-specific transports
 
 ### Manual Middleware Configuration
@@ -144,11 +144,11 @@ If you need to customize middleware registration, you can configure it manually:
 services:
     Zhortein\MultiTenantBundle\Messenger\TenantSendingMiddleware:
         tags:
-            - { name: messenger.middleware, priority: 100 }
+            - { name: messenger.middleware, priority: 150 }
     
     Zhortein\MultiTenantBundle\Messenger\TenantWorkerMiddleware:
         tags:
-            - { name: messenger.middleware, priority: 100 }
+            - { name: messenger.middleware, priority: 200 }
 ```
 
 ## Usage

--- a/src/DependencyInjection/ZhorteinMultiTenantExtension.php
+++ b/src/DependencyInjection/ZhorteinMultiTenantExtension.php
@@ -46,6 +46,8 @@ use Zhortein\MultiTenantBundle\Manager\TenantSettingsManagerInterface;
 use Zhortein\MultiTenantBundle\Messenger\TenantMessengerConfigurator;
 use Zhortein\MultiTenantBundle\Messenger\TenantMessengerTransportFactory;
 use Zhortein\MultiTenantBundle\Messenger\TenantMessengerTransportResolver;
+use Zhortein\MultiTenantBundle\Messenger\TenantSendingMiddleware;
+use Zhortein\MultiTenantBundle\Messenger\TenantWorkerMiddleware;
 use Zhortein\MultiTenantBundle\Observability\EventSubscriber\TenantLoggingSubscriber;
 use Zhortein\MultiTenantBundle\Observability\EventSubscriber\TenantMetricsSubscriber;
 use Zhortein\MultiTenantBundle\Observability\Metrics\MetricsAdapterInterface;
@@ -608,6 +610,16 @@ final class ZhorteinMultiTenantExtension extends Extension implements PrependExt
                 exclude: ['zhortein_multi_tenant.messenger.transport_factory'],
             ))
             ->addTag('messenger.transport_factory');
+
+        $container->register(TenantWorkerMiddleware::class)
+            ->setAutowired(true)
+            ->setAutoconfigured(true)
+            ->addTag('messenger.middleware', ['priority' => 200]);
+
+        $container->register(TenantSendingMiddleware::class)
+            ->setAutowired(true)
+            ->setAutoconfigured(true)
+            ->addTag('messenger.middleware', ['priority' => 150]);
 
         // Register transport resolver middleware
         $container->setAlias(TenantMessengerTransportFactory::class, 'zhortein_multi_tenant.messenger.transport_factory');

--- a/src/Manager/TenantSettingsManager.php
+++ b/src/Manager/TenantSettingsManager.php
@@ -40,7 +40,15 @@ final readonly class TenantSettingsManager implements TenantSettingsManagerInter
     {
         $settings = $this->all();
 
-        return $settings[$key] ?? $this->parameterBag->get("zhortein_multi_tenant.default_settings.$key") ?? $default;
+        if (array_key_exists($key, $settings)) {
+            return $settings[$key];
+        }
+
+        $parameter = "zhortein_multi_tenant.default_settings.$key";
+
+        return $this->parameterBag->has($parameter)
+            ? $this->parameterBag->get($parameter)
+            : $default;
     }
 
     /**

--- a/src/Messenger/TenantMessengerTransportResolver.php
+++ b/src/Messenger/TenantMessengerTransportResolver.php
@@ -44,7 +44,7 @@ final readonly class TenantMessengerTransportResolver implements MiddlewareInter
         }
 
         // Add tenant information as stamps/headers if enabled
-        if ($this->addTenantHeaders && null !== $tenant) {
+        if ($this->addTenantHeaders && null !== $tenant && null === $envelope->last(TenantStamp::class)) {
             $envelope = $this->addTenantStamps($envelope, $tenant);
         }
 

--- a/src/Messenger/TenantWorkerMiddleware.php
+++ b/src/Messenger/TenantWorkerMiddleware.php
@@ -7,6 +7,7 @@ namespace Zhortein\MultiTenantBundle\Messenger;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Zhortein\MultiTenantBundle\Context\TenantContextInterface;
 use Zhortein\MultiTenantBundle\Database\TenantSessionConfigurator;
 use Zhortein\MultiTenantBundle\Doctrine\TenantConnectionResolverInterface;
@@ -24,16 +25,20 @@ final readonly class TenantWorkerMiddleware implements MiddlewareInterface
     public function __construct(
         private TenantContextInterface $tenantContext,
         private TenantRegistryInterface $tenantRegistry,
-        private TenantSessionConfigurator $sessionConfigurator,
+        private ?TenantSessionConfigurator $sessionConfigurator = null,
         private ?TenantConnectionResolverInterface $connectionResolver = null,
     ) {
     }
 
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
+        if (null === $envelope->last(ReceivedStamp::class)) {
+            return $stack->next()->handle($envelope, $stack);
+        }
+
         // A reused worker must start without state from the previous message.
         $this->tenantContext->clear();
-        $this->sessionConfigurator->clearConfig();
+        $this->sessionConfigurator?->clearConfig();
 
         $tenantStamp = $envelope->last(TenantStamp::class);
 
@@ -56,14 +61,14 @@ final readonly class TenantWorkerMiddleware implements MiddlewareInterface
 
         try {
             // Configure database session using TenantSessionConfigurator
-            $this->sessionConfigurator->setConfig();
+            $this->sessionConfigurator?->setConfig();
 
             // Process the message with tenant context
             return $stack->next()->handle($envelope, $stack);
         } finally {
             // Always clear both PHP and database session state after processing.
             $this->tenantContext->clear();
-            $this->sessionConfigurator->clearConfig();
+            $this->sessionConfigurator?->clearConfig();
         }
     }
 }

--- a/tests/DependencyInjection/ZhorteinMultiTenantExtensionTest.php
+++ b/tests/DependencyInjection/ZhorteinMultiTenantExtensionTest.php
@@ -114,6 +114,8 @@ class ZhorteinMultiTenantExtensionTest extends TestCase
             $this->assertTrue($this->container->hasDefinition('zhortein_multi_tenant.messenger.configurator'));
             $this->assertTrue($this->container->hasDefinition('zhortein_multi_tenant.messenger.transport_factory'));
             $this->assertTrue($this->container->hasDefinition('zhortein_multi_tenant.messenger.transport_resolver'));
+            $this->assertTrue($this->container->hasDefinition(\Zhortein\MultiTenantBundle\Messenger\TenantSendingMiddleware::class));
+            $this->assertTrue($this->container->hasDefinition(\Zhortein\MultiTenantBundle\Messenger\TenantWorkerMiddleware::class));
         }
     }
 

--- a/tests/Messenger/TenantMessengerTransportResolverTest.php
+++ b/tests/Messenger/TenantMessengerTransportResolverTest.php
@@ -43,14 +43,14 @@ class TenantMessengerTransportResolverTest extends TestCase
         // Arrange
         $tenant = $this->createMock(TenantInterface::class);
         $tenant->method('getSlug')->willReturn('acme');
-        $tenant->method('getName')->willReturn('Acme Corporation');
+        $tenant->method('getId')->willReturn('123');
 
         $this->tenantContext->method('getTenant')->willReturn($tenant);
 
         $message = new \stdClass();
         $envelope = new Envelope($message);
 
-        $nextMiddleware = $this->createMock(StackInterface::class);
+        $nextMiddleware = $this->createMock(\Symfony\Component\Messenger\Middleware\MiddlewareInterface::class);
         $this->stack->method('next')->willReturn($nextMiddleware);
 
         $nextMiddleware->expects($this->once())
@@ -66,8 +66,7 @@ class TenantMessengerTransportResolverTest extends TestCase
                 $tenantStamp = $envelope->last(TenantStamp::class);
 
                 return $tenantStamp
-                    && 'acme' === $tenantStamp->getTenantSlug()
-                    && 'Acme Corporation' === $tenantStamp->getTenantName();
+                    && '123' === $tenantStamp->getTenantId();
             }), $this->stack)
             ->willReturn($envelope);
 
@@ -83,14 +82,14 @@ class TenantMessengerTransportResolverTest extends TestCase
         // Arrange
         $tenant = $this->createMock(TenantInterface::class);
         $tenant->method('getSlug')->willReturn('unknown');
-        $tenant->method('getName')->willReturn('Unknown Tenant');
+        $tenant->method('getId')->willReturn('456');
 
         $this->tenantContext->method('getTenant')->willReturn($tenant);
 
         $message = new \stdClass();
         $envelope = new Envelope($message);
 
-        $nextMiddleware = $this->createMock(StackInterface::class);
+        $nextMiddleware = $this->createMock(\Symfony\Component\Messenger\Middleware\MiddlewareInterface::class);
         $this->stack->method('next')->willReturn($nextMiddleware);
 
         $nextMiddleware->expects($this->once())
@@ -106,8 +105,7 @@ class TenantMessengerTransportResolverTest extends TestCase
                 $tenantStamp = $envelope->last(TenantStamp::class);
 
                 return $tenantStamp
-                    && 'unknown' === $tenantStamp->getTenantSlug()
-                    && 'Unknown Tenant' === $tenantStamp->getTenantName();
+                    && '456' === $tenantStamp->getTenantId();
             }), $this->stack)
             ->willReturn($envelope);
 
@@ -126,7 +124,7 @@ class TenantMessengerTransportResolverTest extends TestCase
         $message = new \stdClass();
         $envelope = new Envelope($message);
 
-        $nextMiddleware = $this->createMock(StackInterface::class);
+        $nextMiddleware = $this->createMock(\Symfony\Component\Messenger\Middleware\MiddlewareInterface::class);
         $this->stack->method('next')->willReturn($nextMiddleware);
 
         $nextMiddleware->expects($this->once())
@@ -157,7 +155,7 @@ class TenantMessengerTransportResolverTest extends TestCase
         // Arrange
         $tenant = $this->createMock(TenantInterface::class);
         $tenant->method('getSlug')->willReturn('acme');
-        $tenant->method('getName')->willReturn('Acme Corporation');
+        $tenant->method('getId')->willReturn('123');
 
         $this->tenantContext->method('getTenant')->willReturn($tenant);
 
@@ -165,7 +163,7 @@ class TenantMessengerTransportResolverTest extends TestCase
         $existingTransportStamp = new TransportNamesStamp(['existing_transport']);
         $envelope = new Envelope($message, [$existingTransportStamp]);
 
-        $nextMiddleware = $this->createMock(StackInterface::class);
+        $nextMiddleware = $this->createMock(\Symfony\Component\Messenger\Middleware\MiddlewareInterface::class);
         $this->stack->method('next')->willReturn($nextMiddleware);
 
         $nextMiddleware->expects($this->once())
@@ -181,8 +179,7 @@ class TenantMessengerTransportResolverTest extends TestCase
                 $tenantStamp = $envelope->last(TenantStamp::class);
 
                 return $tenantStamp
-                    && 'acme' === $tenantStamp->getTenantSlug()
-                    && 'Acme Corporation' === $tenantStamp->getTenantName();
+                    && '123' === $tenantStamp->getTenantId();
             }), $this->stack)
             ->willReturn($envelope);
 
@@ -205,14 +202,14 @@ class TenantMessengerTransportResolverTest extends TestCase
 
         $tenant = $this->createMock(TenantInterface::class);
         $tenant->method('getSlug')->willReturn('acme');
-        $tenant->method('getName')->willReturn('Acme Corporation');
+        $tenant->method('getId')->willReturn('123');
 
         $this->tenantContext->method('getTenant')->willReturn($tenant);
 
         $message = new \stdClass();
         $envelope = new Envelope($message);
 
-        $nextMiddleware = $this->createMock(StackInterface::class);
+        $nextMiddleware = $this->createMock(\Symfony\Component\Messenger\Middleware\MiddlewareInterface::class);
         $this->stack->method('next')->willReturn($nextMiddleware);
 
         $nextMiddleware->expects($this->once())

--- a/tests/Messenger/TenantWorkerMiddlewareTest.php
+++ b/tests/Messenger/TenantWorkerMiddlewareTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Zhortein\MultiTenantBundle\Context\TenantContextInterface;
 use Zhortein\MultiTenantBundle\Database\TenantSessionConfigurator;
 use Zhortein\MultiTenantBundle\Entity\TenantInterface;
@@ -56,6 +57,21 @@ class TenantWorkerMiddlewareTest extends TestCase
         $this->stack = $this->createMock(StackInterface::class);
     }
 
+    public function testOutgoingDispatchPreservesCurrentTenantContext(): void
+    {
+        $message = new \stdClass();
+        $envelope = new Envelope($message);
+        $nextMiddleware = $this->createMock(\Symfony\Component\Messenger\Middleware\MiddlewareInterface::class);
+
+        $this->tenantContext->expects($this->never())->method('clear');
+        $this->tenantContext->expects($this->never())->method('setTenant');
+        $this->tenantRegistry->expects($this->never())->method('findById');
+        $this->stack->expects($this->once())->method('next')->willReturn($nextMiddleware);
+        $nextMiddleware->expects($this->once())->method('handle')->with($envelope, $this->stack)->willReturn($envelope);
+
+        $this->assertSame($envelope, $this->middleware->handle($envelope, $this->stack));
+    }
+
     public function testHandleWithTenantStampRestoresTenantContext(): void
     {
         // Arrange
@@ -63,7 +79,7 @@ class TenantWorkerMiddlewareTest extends TestCase
         $tenantStamp = new TenantStamp('123');
 
         $message = new \stdClass();
-        $envelope = new Envelope($message, [$tenantStamp]);
+        $envelope = new Envelope($message, [$tenantStamp, new ReceivedStamp('async')]);
 
         $this->tenantRegistry->expects($this->once())
             ->method('findById')
@@ -98,7 +114,7 @@ class TenantWorkerMiddlewareTest extends TestCase
     {
         // Arrange
         $message = new \stdClass();
-        $envelope = new Envelope($message);
+        $envelope = new Envelope($message, [new ReceivedStamp('async')]);
 
         $this->tenantRegistry->expects($this->never())
             ->method('findById');
@@ -132,7 +148,7 @@ class TenantWorkerMiddlewareTest extends TestCase
         $tenantStamp = new TenantStamp('nonexistent');
 
         $message = new \stdClass();
-        $envelope = new Envelope($message, [$tenantStamp]);
+        $envelope = new Envelope($message, [$tenantStamp, new ReceivedStamp('async')]);
 
         $this->tenantRegistry->expects($this->once())
             ->method('findById')
@@ -169,7 +185,7 @@ class TenantWorkerMiddlewareTest extends TestCase
         $tenantStamp = new TenantStamp('123');
 
         $message = new \stdClass();
-        $envelope = new Envelope($message, [$tenantStamp]);
+        $envelope = new Envelope($message, [$tenantStamp, new ReceivedStamp('async')]);
 
         $this->tenantRegistry->expects($this->once())
             ->method('findById')
@@ -210,7 +226,7 @@ class TenantWorkerMiddlewareTest extends TestCase
         $tenantStamp = new TenantStamp('456');
 
         $message = new \stdClass();
-        $envelope = new Envelope($message, [$tenantStamp]);
+        $envelope = new Envelope($message, [$tenantStamp, new ReceivedStamp('async')]);
 
         $this->tenantRegistry->expects($this->once())
             ->method('findById')
@@ -249,7 +265,7 @@ class TenantWorkerMiddlewareTest extends TestCase
         $lastStamp = new TenantStamp('456');
 
         $message = new \stdClass();
-        $envelope = new Envelope($message, [$firstStamp, $lastStamp]);
+        $envelope = new Envelope($message, [$firstStamp, $lastStamp, new ReceivedStamp('async')]);
 
         // Should use the last stamp (456)
         $this->tenantRegistry->expects($this->once())

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -22,6 +22,8 @@ use Zhortein\MultiTenantBundle\Mailer\TenantMailerFallbackTransportFactory;
 use Zhortein\MultiTenantBundle\Messenger\TenantMessengerConfigurator;
 use Zhortein\MultiTenantBundle\Messenger\TenantMessengerTransportFactory;
 use Zhortein\MultiTenantBundle\Messenger\TenantMessengerTransportResolver;
+use Zhortein\MultiTenantBundle\Messenger\TenantSendingMiddleware;
+use Zhortein\MultiTenantBundle\Messenger\TenantWorkerMiddleware;
 use Zhortein\MultiTenantBundle\Repository\TenantSettingRepository;
 
 /**
@@ -127,6 +129,14 @@ final class ConfigurationTest extends TestCase
             $messengerFactories->getExclude(),
         );
         self::assertSame('zhortein_multi_tenant.messenger.transport_resolver', (string) $container->getAlias(TenantMessengerTransportResolver::class));
+
+        foreach ([TenantWorkerMiddleware::class => 200, TenantSendingMiddleware::class => 150] as $service => $priority) {
+            self::assertTrue($container->hasDefinition($service));
+            self::assertSame(
+                [['priority' => $priority]],
+                $container->getDefinition($service)->getTag('messenger.middleware'),
+            );
+        }
     }
 
     public function testMailerFactoryUsesANonRecursiveFallbackAggregate(): void

--- a/tests/Unit/Manager/TenantSettingsManagerTest.php
+++ b/tests/Unit/Manager/TenantSettingsManagerTest.php
@@ -77,6 +77,24 @@ final class TenantSettingsManagerTest extends TestCase
         $this->assertEquals('default_value', $result);
     }
 
+    public function testGetUsesConfiguredParameterFallback(): void
+    {
+        $tenant = $this->createMock(TenantInterface::class);
+        $tenant->method('getId')->willReturn('tenant-1');
+        $this->tenantContext->method('getTenant')->willReturn($tenant);
+
+        $cacheItem = $this->createMock(CacheItemInterface::class);
+        $cacheItem->method('isHit')->willReturn(true);
+        $cacheItem->method('get')->willReturn([]);
+        $this->cache->method('getItem')->willReturn($cacheItem);
+
+        $parameter = 'zhortein_multi_tenant.default_settings.email_reply_to';
+        $this->parameterBag->method('has')->with($parameter)->willReturn(true);
+        $this->parameterBag->method('get')->with($parameter)->willReturn('reply@example.test');
+
+        $this->assertSame('reply@example.test', $this->manager->get('email_reply_to'));
+    }
+
     public function testGetRequiredThrowsExceptionWhenNotFound(): void
     {
         $tenant = $this->createMock(TenantInterface::class);


### PR DESCRIPTION
## Problem

The reference consumer exposed two gaps in the documented optional integration contracts:

- `TenantSettingsManager::get()` requested a container parameter even when that optional fallback parameter did not exist, causing a real `TenantAwareMailer` send to fail for `email_reply_to`.
- Messenger advertised automatic tenant propagation, but the sending and worker middleware were not registered. Outgoing messages therefore lacked a `TenantStamp`.

## Solution and architecture

- Check whether a default-setting parameter exists before reading it and otherwise honor the caller-provided fallback.
- Register `TenantWorkerMiddleware` and `TenantSendingMiddleware` when Messenger integration is enabled.
- Restrict worker restoration and cleanup to envelopes carrying Symfony's `ReceivedStamp`, so ordinary outgoing dispatch cannot clear the active context.
- Keep the RLS session configurator optional for RLS-disabled and multi-database consumers.
- Prevent the transport resolver from duplicating an existing tenant stamp.
- Correct stale Messenger tests to the current tenant-ID stamp contract.

## Compatibility

This implements behavior already documented as automatic. It adds no configuration keys, removes no public API, and preserves existing constructor calls. RLS-enabled workers continue to configure and clear their database session.

## Tests

Local validation:

- Composer validation: passed
- Composer security audit: no advisories
- PHPStan level max: passed
- PHP-CS-Fixer check: passed
- Focused Manager/Messenger tests: 44 tests, 172 assertions
- Unit suite: 324 tests, 934 assertions
- Integration suite: 111 tests, 160 assertions
- Complete declared suite: 453 tests, 1,176 assertions
- Real PostgreSQL/RLS suite: 16 tests, 63 assertions
- Test-kit validation: passed

The existing PHPUnit notices and environment-dependent skips remain visible and were not suppressed.

## Migration impact

None. Applications that enabled Messenger now receive the tenant propagation behavior already promised by the documentation.

Closes #28
