### PR TITLE
Wire Tenant Middleware into the Configured Bus

### DIFF
--- a/src/DependencyInjection/ZhorteinMultiTenantExtension.php
+++ b/src/DependencyInjection/ZhorteinMultiTenantExtension.php
@@ -78,22 +78,40 @@ final class ZhorteinMultiTenantExtension extends Extension implements PrependExt
 {
     public function prepend(ContainerBuilder $container): void
     {
-        if (!$container->hasExtension('doctrine')) {
-            return;
-        }
-
         $config = $this->processConfiguration(
             new Configuration(),
             $container->getExtensionConfig($this->getAlias()),
         );
 
-        $container->prependExtensionConfig('doctrine', [
-            'orm' => [
-                'resolve_target_entities' => [
-                    TenantInterface::class => $config['tenant_entity'],
+        if ($container->hasExtension('doctrine')) {
+            $container->prependExtensionConfig('doctrine', [
+                'orm' => [
+                    'resolve_target_entities' => [
+                        TenantInterface::class => $config['tenant_entity'],
+                    ],
                 ],
-            ],
-        ]);
+            ]);
+        }
+
+        $messengerConfig = $config['messenger'] ?? [];
+        $messengerEnabled = is_array($messengerConfig) && true === ($messengerConfig['enabled'] ?? false);
+        $fallbackBus = is_array($messengerConfig) ? ($messengerConfig['fallback_bus'] ?? null) : null;
+
+        if ($messengerEnabled && is_string($fallbackBus) && $container->hasExtension('framework')) {
+            $container->prependExtensionConfig('framework', [
+                'messenger' => [
+                    'buses' => [
+                        $fallbackBus => [
+                            'middleware' => [
+                                TenantWorkerMiddleware::class,
+                                TenantSendingMiddleware::class,
+                                TenantMessengerTransportResolver::class,
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+        }
     }
 
     public function load(array $configs, ContainerBuilder $container): void

--- a/tests/ConsumerApp/bin/validate.php
+++ b/tests/ConsumerApp/bin/validate.php
@@ -29,5 +29,26 @@ if (false !== $container->getParameter('zhortein_multi_tenant.mailer.add_tenant_
     throw new RuntimeException('Tenant email metadata headers must remain disabled in the consumer fixture.');
 }
 
+$testContainer = $container->get('test.service_container');
+$tenantContext = $testContainer->get(Zhortein\MultiTenantBundle\Context\TenantContextInterface::class);
+$tenantContext->setTenant(new App\Entity\Tenant());
+$testContainer->get(Symfony\Component\Messenger\MessageBusInterface::class)->dispatch(
+    new stdClass(),
+);
+$transport = $testContainer->get('messenger.transport.async');
+if (!$transport instanceof Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport) {
+    throw new RuntimeException('The consumer fixture requires its in-memory async transport.');
+}
+
+$sent = $transport->getSent();
+if (1 !== count($sent)) {
+    throw new RuntimeException('The consumer message was not sent to the async transport.');
+}
+
+$tenantStamps = $sent[0]->all(Zhortein\MultiTenantBundle\Messenger\TenantStamp::class);
+if (1 !== count($tenantStamps) || 'fixture' !== $tenantStamps[0]->getTenantId()) {
+    throw new RuntimeException('The consumer message did not retain exactly one tenant stamp.');
+}
+
 $kernel->shutdown();
 echo sprintf("Consumer container compiled for %s.\n", $strategy);

--- a/tests/ConsumerApp/src/Kernel.php
+++ b/tests/ConsumerApp/src/Kernel.php
@@ -40,7 +40,7 @@ final class Kernel extends BaseKernel
             'mailer' => ['dsn' => 'null://null'],
             'messenger' => [
                 'default_bus' => 'messenger.bus.default',
-                'transports' => ['async' => 'sync://'],
+                'transports' => ['async' => 'in-memory://'],
             ],
         ]);
         $container->loadFromExtension('doctrine', [

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -184,6 +184,32 @@ final class ConfigurationTest extends TestCase
         );
     }
 
+    public function testMessengerMiddlewareIsPrependedToTheConfiguredBus(): void
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new \Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension());
+        $extension = new ZhorteinMultiTenantExtension();
+        $container->registerExtension($extension);
+        $container->loadFromExtension($extension->getAlias(), [
+            'messenger' => [
+                'enabled' => true,
+                'fallback_bus' => 'application.bus',
+            ],
+        ]);
+
+        $extension->prepend($container);
+
+        $frameworkConfig = $container->getExtensionConfig('framework');
+        self::assertSame(
+            [
+                TenantWorkerMiddleware::class,
+                TenantSendingMiddleware::class,
+                TenantMessengerTransportResolver::class,
+            ],
+            $frameworkConfig[0]['messenger']['buses']['application.bus']['middleware'],
+        );
+    }
+
     public function testReferenceUsesCanonicalResolverSyntax(): void
     {
         $reference = (new YamlReferenceDumper())->dump(new Configuration());


### PR DESCRIPTION
## Problem

PR #29 registered the documented tenant middleware services, but the reference demo proved that Symfony does not insert services into a message bus from a custom `messenger.middleware` tag alone. Transported envelopes still lacked `TenantStamp`.

## Solution

- Prepend the worker, sending, and transport resolver middleware to the bus selected by `messenger.fallback_bus`.
- Preserve custom bus names instead of assuming `messenger.bus.default`.
- Strengthen the external consumer fixture: dispatch through the compiled bus to an in-memory transport and require exactly one tenant stamp.
- Validate both shared-database and multi-database consumer kernels.

## Compatibility

No public API or configuration change. This completes the automatic propagation behavior already documented and started in PR #29.

## Tests

- Dependency-injection regression: 20 tests, 45 assertions.
- Reference demo integration suite against the working fix: 4 tests, 62 assertions.
- External consumer fixture: shared_db and multi_db compiled and transported a stamped message.
- PHPStan level max: passed.
- PHP-CS-Fixer check: passed.

The full compatibility matrix remains required before merge.

Continues #28
