### PR TITLE
Verify documentation and release process

### DIFF
--- a/.github/workflows/test-kit.yml
+++ b/.github/workflows/test-kit.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           dependency-versions: highest
 
+      - name: Validate documentation
+        run: php tests/validate-documentation.php
+
       - name: Check coding style
         run: vendor/bin/php-cs-fixer fix --dry-run --diff
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and releases will follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). No tag or GitHub release has been published yet; the RC headings below preserve untagged development history and are not releases.
 
 ## [Unreleased]
 
@@ -20,10 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Classified all earlier RC sections as untagged development history, removed false stable-release and production-readiness claims, and documented the authorized SemVer candidate process.
+- Added automated documentation validation for local links, YAML examples, obsolete resolver structures, and release-status claims.
 - Replaced historical Test Kit documentation for undistributed or nonexistent
   helpers with the canonical minimal API and executable consumer examples.
 
-## [1.0.0-RC3] - 2026-04-05
+## Unreleased development history: RC3 planning (2026-04-05)
 
 ### Security
 
@@ -71,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation Updates**
   - Updated `README.md` and documentation files to reflect Symfony 8 support
 
-## [1.0.0-RC2]
+## Unreleased development history: RC2 planning
 
 ### Added
 - **Observability and Monitoring**
@@ -157,7 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sensitive Data Protection**: Automatic masking of passwords and sensitive information in DSN strings across all command outputs
 - **Tenant Validation**: Comprehensive tenant existence validation before command execution with clear error messages
 
-## [1.0.0-RC1] - 2025-08-01
+## Unreleased development history: RC1 planning (2025-08-01)
 
 ### Added
 - **Core Multi-Tenancy Features**
@@ -226,7 +228,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Interface-based design for extensibility
 - Caching layer for performance optimization
 
-## [Unreleased]
+## Unreleased development history: initial RLS work
 
 ### Added
 - **PostgreSQL Row-Level Security (RLS) Integration**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -380,21 +380,7 @@ Brief description of the changes.
 
 ## Release Process
 
-### Versioning
-
-The project follows [Semantic Versioning](https://semver.org/):
-- **MAJOR**: Breaking changes
-- **MINOR**: New features (backward compatible)
-- **PATCH**: Bug fixes (backward compatible)
-
-### Release Checklist
-
-1. Update CHANGELOG.md
-2. Update version in composer.json
-3. Run full test suite
-4. Create release tag
-5. Update documentation
-6. Announce release
+No release or tag is created as part of ordinary contribution work. The canonical versioning, candidate validation, demo verification, migration, and authorization checklist is documented in [the release process](docs/release-process.md).
 
 ## Getting Help
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # —— 🛠️ Configuration ————————————————————————————————————————————————————————————————
 .DEFAULT_GOAL := help
-.PHONY: help csfixer phpstan installdeps updatedeps composer test test-unit test-integration clean bundle-validate
+.PHONY: help csfixer phpstan installdeps updatedeps composer test test-unit test-integration clean bundle-validate docs-validate
 
 PHP_IMAGE := php:8.3-cli
 DOCKER_VOLUME := -v "$(PWD)":/app -w /app
@@ -105,6 +105,9 @@ test-with-postgres: ## Run RLS tests with PostgreSQL
 validate-testkit: ## Validate Test Kit setup and configuration
 	docker compose -f tests/docker-compose.yml run --rm --no-deps php-rls php tests/validate-testkit.php
 
+docs-validate: ## Validate documentation links and release claims
+	$(DOCKER_RUN) php tests/validate-documentation.php
+
 ## —— 🔧 Bundle-specific ———————————————————————————————————————————————————————————————————
 bundle-validate: ## Validate bundle structure
 	@echo "🔍 Validating bundle structure..."
@@ -130,7 +133,7 @@ dev-setup: installdeps validate-testkit ## Complete development setup
 
 dev-check: composer-validate phpstan csfixer-check test-unit test-kit ## Run all development checks
 
-ci-check: composer-validate phpstan test ## Run CI checks
+ci-check: composer-validate docs-validate phpstan test ## Run CI checks
 
 ci-check-full: composer-validate phpstan test test-with-postgres ## Run CI checks with PostgreSQL
 

--- a/docs/audit-2026-07.md
+++ b/docs/audit-2026-07.md
@@ -122,3 +122,7 @@ The security guide now distinguishes ORM filter coverage from DQL, QueryBuilder,
 ### Multi-database long-running isolation
 
 Issue #11 replaces the previous unproven multi-database lifecycle with real PostgreSQL A/B/A coverage. The regression suite uses two physical databases, proves that markers cannot cross database boundaries, and verifies that a connection is closed when tenant work throws. Schema, migration, fixture, and Messenger paths now clear tenant context between iterations; tenant-specific EntityManagers explicitly close their DBAL connections because closing the ORM EntityManager alone did not reliably close the physical connection.
+
+## Documentation and release-status remediation (2026-08-01)
+
+Issue #13 resolves the remaining publication ambiguity. The RC1, RC2, and RC3 changelog sections are now explicitly classified as untagged development history; no tag or GitHub release is inferred or created. Premature stable and production-readiness claims were removed. A required documentation validator checks local links, parses YAML examples, rejects obsolete nested resolver syntax in examples, and blocks unqualified production-ready claims. The canonical release checklist requires the external consumer and demo pipelines, the complete compatibility matrix, and effective PostgreSQL RLS before separate authorization for any tag or publication.

--- a/docs/dns-txt-resolver.md
+++ b/docs/dns-txt-resolver.md
@@ -627,6 +627,9 @@ zhortein_multi_tenant:
 # _tenant.tenant1.platform.com TXT "tenant1"
 # _tenant.tenant2.platform.com TXT "tenant2"
 
+```
+
+```yaml
 zhortein_multi_tenant:
     resolver: 'dns_txt'
     dns_txt:
@@ -650,6 +653,9 @@ zhortein_multi_tenant:
 # _tenant.acme.com TXT "acme"
 # _tenant.bio.org TXT "bio"
 
+```
+
+```yaml
 zhortein_multi_tenant:
     resolver: 'dns_txt'
 ```

--- a/docs/domain-resolvers.md
+++ b/docs/domain-resolvers.md
@@ -343,6 +343,9 @@ zhortein_multi_tenant:
         base_domain: 'myplatform.com'
 
 # New hybrid configuration
+```
+
+```yaml
 zhortein_multi_tenant:
     resolver: 'hybrid'
     hybrid:
@@ -358,6 +361,9 @@ zhortein_multi_tenant:
     resolver: 'path'
 
 # New domain configuration for custom domains
+```
+
+```yaml
 zhortein_multi_tenant:
     resolver: 'domain'
     domain:
@@ -429,5 +435,4 @@ php bin/console tenant:resolve --domain=bio.myplatform.com
 
 For complete working examples, see:
 - [Domain Resolver Examples](examples/domain-resolver-usage.md)
-- [Hybrid Resolver Examples](examples/hybrid-resolver-usage.md)
-- [Multi-Environment Setup](examples/multi-environment-domains.md)
+- [Domain and Hybrid Resolver Examples](examples/domain-resolver-usage.md)

--- a/docs/examples/domain-resolver-usage.md
+++ b/docs/examples/domain-resolver-usage.md
@@ -337,6 +337,9 @@ zhortein_multi_tenant:
             '*.dev.local': 'use_subdomain_as_slug'
 
 # config/packages/prod/zhortein_multi_tenant.yaml
+```
+
+```yaml
 zhortein_multi_tenant:
     resolver: 'hybrid'
     hybrid:

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,8 @@ Welcome to the comprehensive documentation for the Zhortein Multi-Tenant Bundle,
 - [Dependency classification](dependencies.md) - Required runtime components and optional integrations
 - [Configuration](configuration.md) - Complete configuration reference
 - [Database Strategies](database-strategies.md) - Shared DB vs Multi-DB approaches
-- [Project Overview](project-overview.md) - Architecture and implementation details
+- [Project Overview](project-overview.md) - Architecture and demonstrated project status
+- [Release Process](release-process.md) - SemVer, candidate validation, and publication authorization
 
 ### Core Concepts
 - [Tenant Context](tenant-context.md) - How tenant resolution and access works
@@ -65,7 +66,7 @@ Welcome to the comprehensive documentation for the Zhortein Multi-Tenant Bundle,
 
 ## Overview
 
-The Zhortein Multi-Tenant Bundle provides a comprehensive, production-ready solution for building multi-tenant applications with Symfony 7.4 LTS and Symfony 8.x. It follows Symfony best practices and includes extensive testing and documentation.
+The Zhortein Multi-Tenant Bundle provides a pre-1.0 implementation under active verification for building multi-tenant applications with Symfony 7.4 LTS and Symfony 8.x. It follows Symfony best practices and includes extensive testing and documentation.
 
 ### Key Features
 

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -4,18 +4,15 @@ This document provides a comprehensive overview of the Zhortein Multi-Tenant Bun
 
 > 📖 **Navigation**: [← FAQ](faq.md) | [Back to Documentation Index](index.md) | [RLS Implementation Summary →](rls-implementation-summary.md)
 
-## 🎯 Project Status: ✅ COMPLETE
+## Project status: pre-1.0
 
-The Zhortein Multi-Tenant Bundle is a production-ready, comprehensive solution for building multi-tenant applications with Symfony 7+ and PostgreSQL 16.
+The bundle is under active pre-1.0 verification. Supported combinations and demonstrated guarantees are defined by the compatibility matrix and required CI jobs, not by this overview.
 
 ## 📊 Project Statistics
 
-- **Total Files**: 57+ source files
-- **Lines of Code**: 3000+ lines
-- **Test Coverage**: 71 unit tests with 139 assertions
 - **PHPStan Level**: Maximum (Level 9)
 - **Code Style**: Symfony standards compliant
-- **Documentation**: Complete with examples
+- **Documentation**: validated links and YAML examples
 
 ## 🏗️ Architecture Overview
 
@@ -114,10 +111,10 @@ The Zhortein Multi-Tenant Bundle is a production-ready, comprehensive solution f
 - ✅ Comprehensive console commands
 - ✅ Extensive configuration options
 - ✅ Clear error messages and validation
-- ✅ Complete documentation with examples
+- Documented public contracts with automated link and YAML validation
 - ✅ Easy integration with existing Symfony apps
 
-### Production Ready
+### Release readiness
 - ✅ Security-first design with tenant isolation
 - ✅ Performance optimizations with caching
 - ✅ Scalable architecture for growth
@@ -216,24 +213,24 @@ class ApiKeyTenantResolver implements TenantResolverInterface
 }
 ```
 
-## 🎉 Project Success Metrics
+## Demonstrated project checks
 
 - ✅ **100% PHPStan Compliance**: Zero errors at maximum level
-- ✅ **Comprehensive Test Suite**: 71 tests with 139 assertions
+- **Comprehensive test suite**: PHPUnit and effective PostgreSQL RLS run as required CI checks
 - ✅ **Complete Documentation**: README, CHANGELOG, CONTRIBUTING, and docs/
-- ✅ **Production Ready**: Security, performance, and scalability considered
+- **Release readiness**: not yet declared; follow the release checklist and compatibility evidence
 - ✅ **Developer Friendly**: Easy setup, clear examples, extensive configuration
 - ✅ **Symfony Best Practices**: Following all Symfony 7+ conventions
 - ✅ **Modern PHP**: PHP 8.3+ features with strict typing
 - ✅ **Extensible Architecture**: Interface-based design for customization
 
-## 🏆 Final Status
+## Release status
 
-The Zhortein Multi-Tenant Bundle is **COMPLETE** and ready for:
-- ✅ Production deployment
+The bundle is not yet a published stable release. Current preparation covers:
+- Candidate validation in the external consumer and demo
 - ✅ Community contribution
-- ✅ Package publication
+- Package publication only after an explicitly authorized release
 - ✅ Documentation hosting
-- ✅ Version tagging (1.0.0)
+- No published tag exists yet
 
-The bundle provides a comprehensive, production-ready solution for multi-tenant Symfony applications with PostgreSQL 16 support, following all modern PHP and Symfony best practices.
+The bundle provides a pre-1.0 multi-tenant implementation for multi-tenant Symfony applications with PostgreSQL 16 support, following all modern PHP and Symfony best practices.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,25 @@
+# Release process
+
+No tag or GitHub release currently exists. Changelog entries labelled as historical RC planning describe untagged development work and must not be interpreted as published versions.
+
+## Versioning
+
+The first published contract will use Semantic Versioning. Until a tag is explicitly authorized, all changes remain under `Unreleased`. A breaking pre-1.0 change must include a migration note; after 1.0, public API breaks require a new major version.
+
+## Candidate validation
+
+Before proposing a tag:
+
+1. Freeze the intended public API and move only shipped entries from `Unreleased` into the candidate version.
+2. Run Composer validation and audit, PHPStan at maximum level, PHP-CS-Fixer, the complete PHPUnit suite, and effective PostgreSQL RLS tests.
+3. Require the full PHP/Symfony/Doctrine matrix, including Symfony 7.4 and Symfony 8.1 on PHP 8.5.
+4. Install the candidate through production Composer autoload in the external consumer fixture for `shared_db` and `multi_db`.
+5. Point the demo at the exact candidate commit or package version and run its complete functional and tenant-isolation pipeline.
+6. Review migration guides, documentation links, configuration examples, and release notes.
+7. Obtain separate human authorization before creating a tag, GitHub release, or package publication.
+
+A failed or skipped required isolation check blocks the candidate. Symfony 8.0 remains useful lower-bound coverage while maintained at proportionate cost; it may only be removed through a documented compatibility decision.
+
+## Migration documentation
+
+Every intentional break must state the previous behavior, the new contract, required application or data migration, and rollback considerations. The current security-contract migration is documented in [Security Contract Migration](migration-security-contracts.md).

--- a/docs/tenant-resolution.md
+++ b/docs/tenant-resolution.md
@@ -580,6 +580,9 @@ zhortein_multi_tenant:
     resolver: 'path' # Use path resolver in development
 
 # config/packages/prod/zhortein_multi_tenant.yaml
+```
+
+```yaml
 zhortein_multi_tenant:
     resolver: 'subdomain' # Use subdomain resolver in production
     subdomain:

--- a/tests/validate-documentation.php
+++ b/tests/validate-documentation.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+require $root.'/vendor/autoload.php';
+$documents = array_merge([$root.'/README.md', $root.'/CONTRIBUTING.md', $root.'/CHANGELOG.md'], glob($root.'/docs/*.md') ?: [], glob($root.'/docs/examples/*.md') ?: []);
+$failures = [];
+foreach ($documents as $document) {
+    $contents = file_get_contents($document);
+    if (false === $contents) {
+        $failures[] = sprintf('Cannot read %s.', $document);
+        continue;
+    }
+    preg_match_all("/```ya?ml\s*\n(.*?)```/s", $contents, $yamlBlocks);
+    foreach ($yamlBlocks[1] as $yaml) {
+        try {
+            Symfony\Component\Yaml\Yaml::parse($yaml);
+        } catch (Symfony\Component\Yaml\Exception\ParseException $exception) {
+            $failures[] = sprintf('%s contains invalid YAML: %s', substr($document, strlen($root) + 1), $exception->getMessage());
+        }
+        if (preg_match("/^\s*(?:resolver\s*:\s*\n\s+type|resolution\s*:\s*\n\s+strategy)\s*:/m", $yaml)) {
+            $failures[] = sprintf('%s contains obsolete resolver configuration.', substr($document, strlen($root) + 1));
+        }
+    }
+
+    preg_match_all("/\[[^]]+]\(([^)]+)\)/", $contents, $links);
+    foreach ($links[1] as $link) {
+        $target = explode('#', $link, 2)[0];
+        if ('' === $target || preg_match('{^(?:https?://|mailto:)}', $target)) {
+            continue;
+        }
+        if (!file_exists(dirname($document).'/'.rawurldecode($target))) {
+            $failures[] = sprintf('%s links to missing local target %s.', substr($document, strlen($root) + 1), $link);
+        }
+    }
+    if (preg_match('/production[ -]ready/i', $contents) && !str_contains($document, 'audit-2026-07.md')) {
+        $failures[] = sprintf('%s contains an unqualified production-ready claim.', substr($document, strlen($root) + 1));
+    }
+}
+if ([] !== $failures) {
+    fwrite(STDERR, implode("\n", array_map(static fn (string $failure): string => 'ERROR: '.$failure, $failures))."\n");
+    exit(1);
+}
+fwrite(STDOUT, sprintf("Validated %d documentation files and their local links.\n", count($documents)));


### PR DESCRIPTION
Closes #13

## Problem

Documentation still presented untagged RC planning as published releases, included premature production-readiness claims, contained broken links, and combined alternative configurations into invalid YAML blocks. Documentation drift was not a required CI failure.

## Solution

- Reclassify RC1, RC2, and RC3 sections as untagged development history and retain a single canonical Unreleased section.
- Remove false stable-release and production-readiness claims without creating tags or releases.
- Add the canonical SemVer candidate, migration, demo validation, and publication authorization checklist.
- Add a required documentation validator that checks all local links, parses every YAML example, rejects obsolete nested resolver structures, and blocks unqualified production-ready claims.
- Split combined environment alternatives into independently valid canonical YAML examples and remove links to nonexistent guides.
- Record the remediation in the audit report.

## Demonstrated, optional, and future status

Supported compatibility and isolation guarantees are demonstrated by required CI jobs. Optional integrations remain documented as optional dependencies. Publication, a stable 1.0 contract, tags, and releases remain future actions requiring separate authorization. Symfony 8.0 remains useful lower-bound coverage and is retained.

## Validation

- Documentation validator: 45 files and all local links passed; all YAML examples parsed
- Composer validation: passed
- Composer security audit: no advisories
- PHPStan at maximum configured level: passed
- PHP-CS-Fixer check: passed
- PHPUnit: 457 tests, 1187 assertions; passed (existing notices and environment-dependent non-RLS skips retained)
- Effective PostgreSQL RLS: 16 tests, 63 assertions; passed with no skips

The existing external consumer matrix continues to validate the canonical public Test Kit and both shared_db and multi_db strategies. The release checklist additionally requires the demo pipeline against the exact candidate before any separately authorized tag or publication.