### PR TITLE
Update GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/test-kit.yml
+++ b/.github/workflows/test-kit.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -24,7 +24,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@v4
         with:
           dependency-versions: highest
 
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -80,7 +80,7 @@ jobs:
         working-directory: /tmp/consumer
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Prepare external consumer directory
         working-directory: ${{ github.workspace }}
@@ -225,7 +225,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Closes #34

## Summary

- update `actions/checkout` from v4 to v7
- update `ramsey/composer-install` from v3 to v4, which updates its cache dependency to Node.js 24
- preserve the existing read-only workflow permissions and all job inputs

## Compatibility notes

The new majors require modern Actions runners; this repository uses GitHub-hosted `ubuntu-latest` runners. No workflow inputs or outputs used here changed.

## Validation

- `git diff --check`
- full compatibility matrix required before merge