### PR TITLE
Configure monthly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+
+updates:
+  - package-ecosystem: composer
+    directory: /
+    target-branch: develop
+    schedule:
+      interval: monthly
+    groups:
+      compatible-non-breaking-updates:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: develop
+    schedule:
+      interval: monthly
+    groups:
+      compatible-non-breaking-updates:
+        update-types:
+          - minor
+          - patch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -352,6 +352,26 @@ final class TenantContext implements TenantContextInterface
 - **Breaking Changes**: Clearly mark any breaking changes
 - **Issue References**: Reference related issues
 
+### Dependabot Branch Synchronization
+
+Dependabot version-update pull requests target `develop`. If a Dependabot pull
+request is exceptionally merged directly into `main`, synchronize `main` back
+into `develop` immediately through a pull request:
+
+```bash
+git fetch origin
+git switch develop
+git pull --ff-only origin develop
+git switch -c chore/synchronize-main-after-dependabot
+git merge --no-ff origin/main
+git push --set-upstream origin chore/synchronize-main-after-dependabot
+```
+
+Open the resulting pull request against `develop`, allow the complete CI suite
+to pass, and merge it without rebasing or squashing away the synchronization
+merge. Resolve any conflict in favor of preserving both the published `main`
+history and subsequent `develop` work.
+
 ### Pull Request Template
 
 ```markdown


### PR DESCRIPTION
## Summary

- add monthly Composer version updates targeting `develop`
- add monthly GitHub Actions updates targeting `develop`
- group compatible minor and patch updates by ecosystem
- document the exceptional `main`-to-`develop` synchronization procedure

Dependabot does not perform automatic merges.

## Validation

- Dependabot YAML parsed successfully
- Required configuration invariants verified
- `git diff --check`
- `make docs-validate`
